### PR TITLE
feat: support controlling camel-case conversion

### DIFF
--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -19,6 +19,19 @@ export interface TypeGeneratorOptions {
    * @default - $refs are not supported
    */
   readonly definitions?: { [def: string]: JSONSchema4 };
+
+  /**
+   * Convert all property names to camel case so they are idiomatic in
+   * TypeScript/JavaScript.
+   *
+   * The implication is that generated interfaces will not use the same casing
+   * as the JSON schema and will need to be converted back to the original
+   * casing in serialization. This is impossible to do safely since case
+   * conversaion is lossy.
+   *
+   * @default false
+   */
+  readonly camelCase?: boolean;
 }
 
 /**
@@ -53,6 +66,7 @@ export class TypeGenerator {
   private readonly emittedTypes = new Set<string>();
   private readonly exclude: string[];
   private readonly definitions: { [def: string]: JSONSchema4 };
+  private readonly camelCase: boolean;
 
   /**
    *
@@ -61,6 +75,7 @@ export class TypeGenerator {
    */
   constructor(options: TypeGeneratorOptions = { }) {
     this.exclude = options.exclude ?? [];
+    this.camelCase = options.camelCase ?? false;
     this.definitions = {};
 
     for (const [typeName, def] of Object.entries(options.definitions ?? {})) {
@@ -303,8 +318,10 @@ export class TypeGenerator {
 
     // if name is not camelCase, convert it to camel case, but this is likely to
     // produce invalid output during synthesis, so add some annotation to the docs.
-    if (name[0] === name[0].toUpperCase()) {
-      name = camelCase(name);
+    if (this.camelCase) {
+      if (name[0] === name[0].toUpperCase()) {
+        name = camelCase(name);
+      }
     }
 
     // if the name starts with '$' (like $ref or $schema), we remove the "$"

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`camelCase By default (disabled), properties will keep their original casing in generated structs 1`] = `
+"/**
+ * @schema TypeA
+ */
+export interface TypeA {
+  /**
+   * @schema TypeA#FooBar
+   */
+  readonly FooBar?: string;
+
+  /**
+   * @schema TypeA#GooBear
+   */
+  readonly GooBear?: number;
+
+}
+"
+`;
+
+exports[`camelCase If enabled, properties be converted to camel case 1`] = `
+"/**
+ * @schema TypeA
+ */
+export interface TypeA {
+  /**
+   * @schema TypeA#FooBar
+   */
+  readonly fooBar?: string;
+
+  /**
+   * @schema TypeA#GooBear
+   */
+  readonly gooBear?: number;
+
+}
+"
+`;
+
 exports[`documentation "*/" is is escaped 1`] = `
 "/**
  * @schema fqn.of.TestType

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -301,6 +301,49 @@ describe('type aliases', () => {
 
 });
 
+describe('camelCase', () => {
+
+  test('By default (disabled), properties will keep their original casing in generated structs', () => {
+    // GIVEN
+    const gen = new TypeGenerator();
+
+    gen.addDefinition('TypeA', {
+      type: 'object',
+      properties: {
+        FooBar: { type: 'string' },
+        GooBear: { type: 'number' },
+      },
+    });
+
+    // WHEN
+    gen.emitType('TypeA');
+
+    // THEN
+    expect(gen.render()).toMatchSnapshot();
+  });
+
+  test('If enabled, properties be converted to camel case', () => {
+    // GIVEN
+    const gen = new TypeGenerator({ camelCase: true });
+
+    gen.addDefinition('TypeA', {
+      type: 'object',
+      properties: {
+        FooBar: { type: 'string' },
+        GooBear: { type: 'number' },
+      },
+    });
+
+    // WHEN
+    gen.emitType('TypeA');
+
+    // THEN
+    expect(gen.render()).toMatchSnapshot();
+  });
+
+
+});
+
 
 function which(name: string, schema: JSONSchema4, definitions?: JSONSchema4) {
   test(name, async () => {


### PR DESCRIPTION
json2jsii supports converting property names to camel case so they are typescript-idiomatic. The problem with doing this conversion is that it is “lossy” and converting back from camel case to domain-specific capitalization is impossible without the source schema.

This commit adds a `camelCase` option which allows enabling/disabling case conversion. Due to the above mentioned limitation, this setting is now disabled by default so case conversion only happens if explicitly
requested.

BREAKING CHANGE: property names will no longer be converted to camel case by default. To enable, set `camelCase` to `true` when creating a `TypeGenerator` object.

