### PR TITLE
fix: remove resolve method from union types

### DIFF
--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -370,7 +370,6 @@ export class TypeGenerator {
       }
 
       code.openBlock('private constructor(public readonly value: any)');
-      code.line('Object.defineProperty(this, \'resolve\', { value: () => value });');
       code.closeBlock();
 
       code.closeBlock();

--- a/test/__snapshots__/tojson.test.ts.snap
+++ b/test/__snapshots__/tojson.test.ts.snap
@@ -548,7 +548,6 @@ export class IntOrString {
     return new IntOrString(value);
   }
   private constructor(public readonly value: any) {
-    Object.defineProperty(this, 'resolve', { value: () => value });
   }
 }
 
@@ -563,7 +562,6 @@ export class MyStructHaver {
     return new MyStructHaver(value);
   }
   private constructor(public readonly value: any) {
-    Object.defineProperty(this, 'resolve', { value: () => value });
   }
 }
 "

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -1474,7 +1474,6 @@ export class TestType {
     return new TestType(value);
   }
   private constructor(public readonly value: any) {
-    Object.defineProperty(this, 'resolve', { value: () => value });
   }
 }
 "


### PR DESCRIPTION
Relates to https://github.com/cdk8s-team/cdk8s-plus-17/issues/56

The `resolve()` method is not entirely needed since there is a `value` property publicly exposed. This method caused some problems when were trying to JSON-ify objects in cdk8s where IntOrString values had already been resolved.

BREAKING CHANGE: union classes do not implement "resolve()" anymore. Use "toJson_xxx" to serialize.