### PR TITLE
fix: non-symbolic enum members cannot be rendered

### DIFF
--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -457,7 +457,12 @@ export class TypeGenerator {
         }
 
         // sluggify and turn to UPPER_SNAKE_CASE
-        const memberName = snakeCase(value.replace(/[^a-z0-9]/gi, '_')).split('_').filter(x => x).join('_').toUpperCase();
+        let memberName = snakeCase(value.replace(/[^a-z0-9]/gi, '_')).split('_').filter(x => x).join('_').toUpperCase();
+
+        // if member name starts with a non-alpha character, add a prefix so it becomes a symbol
+        if (!/^[A-Z].*/i.test(memberName)) {
+          memberName = 'VALUE_' + memberName;
+        }
 
         code.line(`/** ${value} */`);
         code.line(`${memberName} = '${value}',`);

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1,0 +1,848 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generate struct for aqua-enterprise-enforcer.json 1`] = `
+"/**
+ * A resource provider for Aqua Enterprise Enforcer.
+ *
+ * @schema MyStruct
+ */
+export interface MyStruct {
+  /**
+   * EKS cluster name
+   *
+   * @schema MyStruct#ClusterID
+   */
+  readonly clusterId?: string;
+
+  /**
+   * Secrets Manager ARN for kubeconfig file
+   *
+   * @schema MyStruct#KubeConfig
+   */
+  readonly kubeConfig?: string;
+
+  /**
+   * IAM to use with EKS cluster authentication, if not resource execution role will be used
+   *
+   * @schema MyStruct#RoleArn
+   */
+  readonly roleArn?: string;
+
+  /**
+   * Namespace to use with helm. Created if doesn't exist and default will be used if not provided
+   *
+   * @schema MyStruct#Namespace
+   */
+  readonly namespace?: string;
+
+  /**
+   * Name for the helm release
+   *
+   * @schema MyStruct#Name
+   */
+  readonly name?: string;
+
+  /**
+   * Custom Values can optionally be specified
+   *
+   * @schema MyStruct#Values
+   */
+  readonly values?: any;
+
+  /**
+   * String representation of a values.yaml file
+   *
+   * @schema MyStruct#ValueYaml
+   */
+  readonly valueYaml?: string;
+
+  /**
+   * Version can be specified, if not latest will be used
+   *
+   * @schema MyStruct#Version
+   */
+  readonly version?: string;
+
+  /**
+   * Custom Value Yaml file can optionally be specified
+   *
+   * @schema MyStruct#ValueOverrideURL
+   */
+  readonly valueOverrideUrl?: string;
+
+  /**
+   * Primary identifier for Cloudformation
+   *
+   * @schema MyStruct#ID
+   */
+  readonly id?: string;
+
+  /**
+   * Timeout for resource provider. Default 60 mins
+   *
+   * @schema MyStruct#TimeOut
+   */
+  readonly timeOut?: number;
+
+  /**
+   * For network connectivity to Cluster inside VPC
+   *
+   * @schema MyStruct#VPCConfiguration
+   */
+  readonly vpcConfiguration?: MyStructVpcConfiguration;
+
+}
+
+/**
+ * Converts an object of type 'MyStruct' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MyStruct(obj: MyStruct | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'ClusterID': obj.clusterId,
+    'KubeConfig': obj.kubeConfig,
+    'RoleArn': obj.roleArn,
+    'Namespace': obj.namespace,
+    'Name': obj.name,
+    'Values': obj.values,
+    'ValueYaml': obj.valueYaml,
+    'Version': obj.version,
+    'ValueOverrideURL': obj.valueOverrideUrl,
+    'ID': obj.id,
+    'TimeOut': obj.timeOut,
+    'VPCConfiguration': toJson_MyStructVpcConfiguration(obj.vpcConfiguration),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * For network connectivity to Cluster inside VPC
+ *
+ * @schema MyStructVpcConfiguration
+ */
+export interface MyStructVpcConfiguration {
+  /**
+   * Specify one or more security groups
+   *
+   * @schema MyStructVpcConfiguration#SecurityGroupIds
+   */
+  readonly securityGroupIds?: string[];
+
+  /**
+   * Specify one or more subnets
+   *
+   * @schema MyStructVpcConfiguration#SubnetIds
+   */
+  readonly subnetIds?: string[];
+
+}
+
+/**
+ * Converts an object of type 'MyStructVpcConfiguration' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MyStructVpcConfiguration(obj: MyStructVpcConfiguration | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'SecurityGroupIds': obj.securityGroupIds?.map(y => y),
+    'SubnetIds': obj.subnetIds?.map(y => y),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+"
+`;
+
+exports[`generate struct for datadog.json 1`] = `
+"/**
+ * Datadog SLO 1.0.0
+ *
+ * @schema MyStruct
+ */
+export interface MyStruct {
+  /**
+   * @schema MyStruct#Creator
+   */
+  readonly creator?: Creator;
+
+  /**
+   * Description of the slo
+   *
+   * @schema MyStruct#Description
+   */
+  readonly description?: string;
+
+  /**
+   * A list of (up to 20) monitor groups that narrow the scope of a monitor service level objective.
+   *
+   * @schema MyStruct#Groups
+   */
+  readonly groups?: string[];
+
+  /**
+   * ID of the slo
+   *
+   * @schema MyStruct#Id
+   */
+  readonly id?: string;
+
+  /**
+   * A list of monitor ids that defines the scope of a monitor service level objective. Required if type is monitor.
+   *
+   * @schema MyStruct#MonitorIds
+   */
+  readonly monitorIds?: number[];
+
+  /**
+   * Name of the slo
+   *
+   * @schema MyStruct#Name
+   */
+  readonly name: string;
+
+  /**
+   * @schema MyStruct#Query
+   */
+  readonly query?: Query;
+
+  /**
+   * Tags associated with the slo
+   *
+   * @schema MyStruct#Tags
+   */
+  readonly tags?: string[];
+
+  /**
+   * @schema MyStruct#Thresholds
+   */
+  readonly thresholds: Threshold[];
+
+  /**
+   * The type of the slo
+   *
+   * @schema MyStruct#Type
+   */
+  readonly type: MyStructType;
+
+  /**
+   * Date of creation of the slo
+   *
+   * @schema MyStruct#Created
+   */
+  readonly created?: Date;
+
+  /**
+   * Date of deletion of the slo
+   *
+   * @schema MyStruct#Deleted
+   */
+  readonly deleted?: Date;
+
+  /**
+   * Date of modification of the slo
+   *
+   * @schema MyStruct#Modified
+   */
+  readonly modified?: Date;
+
+}
+
+/**
+ * Converts an object of type 'MyStruct' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MyStruct(obj: MyStruct | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Creator': toJson_Creator(obj.creator),
+    'Description': obj.description,
+    'Groups': obj.groups?.map(y => y),
+    'Id': obj.id,
+    'MonitorIds': obj.monitorIds?.map(y => y),
+    'Name': obj.name,
+    'Query': toJson_Query(obj.query),
+    'Tags': obj.tags?.map(y => y),
+    'Thresholds': obj.thresholds?.map(y => toJson_Threshold(y)),
+    'Type': obj.type,
+    'Created': obj.created?.toISOString(),
+    'Deleted': obj.deleted?.toISOString(),
+    'Modified': obj.modified?.toISOString(),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema Creator
+ */
+export interface Creator {
+  /**
+   * Name of the creator of the slo
+   *
+   * @schema Creator#Name
+   */
+  readonly name?: string;
+
+  /**
+   * Handle of the creator of the slo
+   *
+   * @schema Creator#Handle
+   */
+  readonly handle?: string;
+
+  /**
+   * Email of the creator of the slo
+   *
+   * @schema Creator#Email
+   */
+  readonly email?: string;
+
+}
+
+/**
+ * Converts an object of type 'Creator' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_Creator(obj: Creator | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Name': obj.name,
+    'Handle': obj.handle,
+    'Email': obj.email,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema Query
+ */
+export interface Query {
+  /**
+   * A Datadog metric query for total (valid) events.
+   *
+   * @schema Query#Numerator
+   */
+  readonly numerator?: string;
+
+  /**
+   * A Datadog metric query for good events.
+   *
+   * @schema Query#Denominator
+   */
+  readonly denominator?: string;
+
+}
+
+/**
+ * Converts an object of type 'Query' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_Query(obj: Query | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Numerator': obj.numerator,
+    'Denominator': obj.denominator,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema Threshold
+ */
+export interface Threshold {
+  /**
+   * The target value for the service level indicator within the corresponding timeframe.
+   *
+   * @schema Threshold#Target
+   */
+  readonly target?: number;
+
+  /**
+   * A string representation of the target that indicates its precision.(e.g. 98.00)
+   *
+   * @schema Threshold#TargetDisplay
+   */
+  readonly targetDisplay?: string;
+
+  /**
+   * The SLO time window options. Allowed enum values: 7d,30d,90d
+   *
+   * @schema Threshold#Timeframe
+   */
+  readonly timeframe?: ThresholdTimeframe;
+
+  /**
+   * The warning value for the service level objective.
+   *
+   * @schema Threshold#Warning
+   */
+  readonly warning?: number;
+
+  /**
+   * A string representation of the warning target.(e.g. 98.00)
+   *
+   * @schema Threshold#WarningDisplay
+   */
+  readonly warningDisplay?: string;
+
+}
+
+/**
+ * Converts an object of type 'Threshold' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_Threshold(obj: Threshold | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Target': obj.target,
+    'TargetDisplay': obj.targetDisplay,
+    'Timeframe': obj.timeframe,
+    'Warning': obj.warning,
+    'WarningDisplay': obj.warningDisplay,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * The type of the slo
+ *
+ * @schema MyStructType
+ */
+export enum MyStructType {
+  /** monitor */
+  MONITOR = 'monitor',
+  /** metric */
+  METRIC = 'metric',
+}
+
+/**
+ * The SLO time window options. Allowed enum values: 7d,30d,90d
+ *
+ * @schema ThresholdTimeframe
+ */
+export enum ThresholdTimeframe {
+  /** 7d */
+  VALUE_7D = '7d',
+  /** 30d */
+  VALUE_30D = '30d',
+  /** 90d */
+  VALUE_90D = '90d',
+}
+"
+`;
+
+exports[`generate struct for eks.json 1`] = `
+"/**
+ * A resource that creates Amazon Elastic Kubernetes Service (Amazon EKS) clusters.
+ *
+ * @schema MyStruct
+ */
+export interface MyStruct {
+  /**
+   * A unique name for your cluster.
+   *
+   * @schema MyStruct#Name
+   */
+  readonly name?: string;
+
+  /**
+   * Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role. This provides permissions for Amazon EKS to call other AWS APIs.
+   *
+   * @schema MyStruct#RoleArn
+   */
+  readonly roleArn: string;
+
+  /**
+   * Name of the AWS Identity and Access Management (IAM) role used for clusters that have the public endpoint disabled. this provides permissions for Lambda to be invoked and attach to the cluster VPC
+   *
+   * @schema MyStruct#LambdaRoleName
+   */
+  readonly lambdaRoleName?: string;
+
+  /**
+   * Desired Kubernetes version for your cluster. If you don't specify this value, the cluster uses the latest version from Amazon EKS.
+   *
+   * @schema MyStruct#Version
+   */
+  readonly version?: string;
+
+  /**
+   * Network configuration for Amazon EKS cluster.
+   *
+   *
+   *
+   * @schema MyStruct#KubernetesNetworkConfig
+   */
+  readonly kubernetesNetworkConfig?: MyStructKubernetesNetworkConfig;
+
+  /**
+   * An object that represents the virtual private cloud (VPC) configuration to use for an Amazon EKS cluster.
+   *
+   * @schema MyStruct#ResourcesVpcConfig
+   */
+  readonly resourcesVpcConfig: MyStructResourcesVpcConfig;
+
+  /**
+   * Enables exporting of logs from the Kubernetes control plane to Amazon CloudWatch Logs. By default, logs from the cluster control plane are not exported to CloudWatch Logs. The valid log types are api, audit, authenticator, controllerManager, and scheduler.
+   *
+   * @schema MyStruct#EnabledClusterLoggingTypes
+   */
+  readonly enabledClusterLoggingTypes?: string[];
+
+  /**
+   * Encryption configuration for the cluster.
+   *
+   * @schema MyStruct#EncryptionConfig
+   */
+  readonly encryptionConfig?: EncryptionConfigEntry[];
+
+  /**
+   * @schema MyStruct#KubernetesApiAccess
+   */
+  readonly kubernetesApiAccess?: MyStructKubernetesApiAccess;
+
+  /**
+   * ARN of the cluster (e.g., \`arn:aws:eks:us-west-2:666666666666:cluster/prod\`).
+   *
+   * @schema MyStruct#Arn
+   */
+  readonly arn?: string;
+
+  /**
+   * Certificate authority data for your cluster.
+   *
+   * @schema MyStruct#CertificateAuthorityData
+   */
+  readonly certificateAuthorityData?: string;
+
+  /**
+   * Security group that was created by Amazon EKS for your cluster. Managed-node groups use this security group for control-plane-to-data-plane communications.
+   *
+   * @schema MyStruct#ClusterSecurityGroupId
+   */
+  readonly clusterSecurityGroupId?: string;
+
+  /**
+   * Endpoint for your Kubernetes API server (e.g., https://5E1D0CEXAMPLEA591B746AFC5AB30262.yl4.us-west-2.eks.amazonaws.com).
+   *
+   * @schema MyStruct#Endpoint
+   */
+  readonly endpoint?: string;
+
+  /**
+   * ARN or alias of the customer master key (CMK).
+   *
+   * @schema MyStruct#EncryptionConfigKeyArn
+   */
+  readonly encryptionConfigKeyArn?: string;
+
+  /**
+   * Issuer URL for the OpenID Connect identity provider.
+   *
+   * @schema MyStruct#OIDCIssuerURL
+   */
+  readonly oidcIssuerUrl?: string;
+
+  /**
+   * @schema MyStruct#Tags
+   */
+  readonly tags?: MyStructTags[];
+
+}
+
+/**
+ * Converts an object of type 'MyStruct' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MyStruct(obj: MyStruct | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Name': obj.name,
+    'RoleArn': obj.roleArn,
+    'LambdaRoleName': obj.lambdaRoleName,
+    'Version': obj.version,
+    'KubernetesNetworkConfig': toJson_MyStructKubernetesNetworkConfig(obj.kubernetesNetworkConfig),
+    'ResourcesVpcConfig': toJson_MyStructResourcesVpcConfig(obj.resourcesVpcConfig),
+    'EnabledClusterLoggingTypes': obj.enabledClusterLoggingTypes?.map(y => y),
+    'EncryptionConfig': obj.encryptionConfig?.map(y => toJson_EncryptionConfigEntry(y)),
+    'KubernetesApiAccess': toJson_MyStructKubernetesApiAccess(obj.kubernetesApiAccess),
+    'Arn': obj.arn,
+    'CertificateAuthorityData': obj.certificateAuthorityData,
+    'ClusterSecurityGroupId': obj.clusterSecurityGroupId,
+    'Endpoint': obj.endpoint,
+    'EncryptionConfigKeyArn': obj.encryptionConfigKeyArn,
+    'OIDCIssuerURL': obj.oidcIssuerUrl,
+    'Tags': obj.tags?.map(y => toJson_MyStructTags(y)),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * Network configuration for Amazon EKS cluster.
+ *
+ *
+ *
+ * @schema MyStructKubernetesNetworkConfig
+ */
+export interface MyStructKubernetesNetworkConfig {
+  /**
+   * Specify the range from which cluster services will receive IPv4 addresses.
+   *
+   * @schema MyStructKubernetesNetworkConfig#ServiceIpv4Cidr
+   */
+  readonly serviceIpv4Cidr?: string;
+
+}
+
+/**
+ * Converts an object of type 'MyStructKubernetesNetworkConfig' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MyStructKubernetesNetworkConfig(obj: MyStructKubernetesNetworkConfig | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'ServiceIpv4Cidr': obj.serviceIpv4Cidr,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * An object that represents the virtual private cloud (VPC) configuration to use for an Amazon EKS cluster.
+ *
+ * @schema MyStructResourcesVpcConfig
+ */
+export interface MyStructResourcesVpcConfig {
+  /**
+   * Specify one or more security groups for the cross-account elastic network interfaces that Amazon EKS creates to use to allow communication between your worker nodes and the Kubernetes control plane. If you don't specify a security group, the default security group for your VPC is used.
+   *
+   * @schema MyStructResourcesVpcConfig#SecurityGroupIds
+   */
+  readonly securityGroupIds?: string[];
+
+  /**
+   * Specify subnets for your Amazon EKS worker nodes. Amazon EKS creates cross-account elastic network interfaces in these subnets to allow communication between your worker nodes and the Kubernetes control plane.
+   *
+   * @schema MyStructResourcesVpcConfig#SubnetIds
+   */
+  readonly subnetIds: string[];
+
+  /**
+   * Set this value to false to disable public access to your cluster's Kubernetes API server endpoint. If you disable public access, your cluster's Kubernetes API server can only receive requests from within the cluster VPC. The default value for this parameter is true , which enables public access for your Kubernetes API server.
+   *
+   * @schema MyStructResourcesVpcConfig#EndpointPublicAccess
+   */
+  readonly endpointPublicAccess?: boolean;
+
+  /**
+   * Set this value to true to enable private access for your cluster's Kubernetes API server endpoint. If you enable private access, Kubernetes API requests from within your cluster's VPC use the private VPC endpoint. The default value for this parameter is false , which disables private access for your Kubernetes API server. If you disable private access and you have worker nodes or AWS Fargate pods in the cluster, then ensure that publicAccessCidrs includes the necessary CIDR blocks for communication with the worker nodes or Fargate pods.
+   *
+   * @schema MyStructResourcesVpcConfig#EndpointPrivateAccess
+   */
+  readonly endpointPrivateAccess?: boolean;
+
+  /**
+   * The CIDR blocks that are allowed access to your cluster's public Kubernetes API server endpoint. Communication to the endpoint from addresses outside of the CIDR blocks that you specify is denied. The default value is 0.0.0.0/0 . If you've disabled private endpoint access and you have worker nodes or AWS Fargate pods in the cluster, then ensure that you specify the necessary CIDR blocks.
+   *
+   * @schema MyStructResourcesVpcConfig#PublicAccessCidrs
+   */
+  readonly publicAccessCidrs?: string[];
+
+}
+
+/**
+ * Converts an object of type 'MyStructResourcesVpcConfig' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MyStructResourcesVpcConfig(obj: MyStructResourcesVpcConfig | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'SecurityGroupIds': obj.securityGroupIds?.map(y => y),
+    'SubnetIds': obj.subnetIds?.map(y => y),
+    'EndpointPublicAccess': obj.endpointPublicAccess,
+    'EndpointPrivateAccess': obj.endpointPrivateAccess,
+    'PublicAccessCidrs': obj.publicAccessCidrs?.map(y => y),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * The encryption configuration for the cluster.
+ *
+ * @schema EncryptionConfigEntry
+ */
+export interface EncryptionConfigEntry {
+  /**
+   * Specifies the resources to be encrypted. The only supported value is \\"secrets\\".
+   *
+   * @schema EncryptionConfigEntry#Resources
+   */
+  readonly resources?: string[];
+
+  /**
+   * @schema EncryptionConfigEntry#Provider
+   */
+  readonly provider?: Provider;
+
+}
+
+/**
+ * Converts an object of type 'EncryptionConfigEntry' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_EncryptionConfigEntry(obj: EncryptionConfigEntry | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Resources': obj.resources?.map(y => y),
+    'Provider': toJson_Provider(obj.provider),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema MyStructKubernetesApiAccess
+ */
+export interface MyStructKubernetesApiAccess {
+  /**
+   * @schema MyStructKubernetesApiAccess#Roles
+   */
+  readonly roles?: KubernetesApiAccessEntry[];
+
+  /**
+   * @schema MyStructKubernetesApiAccess#Users
+   */
+  readonly users?: KubernetesApiAccessEntry[];
+
+}
+
+/**
+ * Converts an object of type 'MyStructKubernetesApiAccess' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MyStructKubernetesApiAccess(obj: MyStructKubernetesApiAccess | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Roles': obj.roles?.map(y => toJson_KubernetesApiAccessEntry(y)),
+    'Users': obj.users?.map(y => toJson_KubernetesApiAccessEntry(y)),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema MyStructTags
+ */
+export interface MyStructTags {
+  /**
+   * @schema MyStructTags#Value
+   */
+  readonly value: string;
+
+  /**
+   * @schema MyStructTags#Key
+   */
+  readonly key: string;
+
+}
+
+/**
+ * Converts an object of type 'MyStructTags' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MyStructTags(obj: MyStructTags | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Value': obj.value,
+    'Key': obj.key,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * AWS Key Management Service (AWS KMS) customer master key (CMK). Either the ARN or the alias can be used.
+ *
+ * @schema Provider
+ */
+export interface Provider {
+  /**
+   * Amazon Resource Name (ARN) or alias of the customer master key (CMK). The CMK must be symmetric, created in the same region as the cluster, and if the CMK was created in a different account, the user must have access to the CMK.
+   *
+   * @schema Provider#KeyArn
+   */
+  readonly keyArn?: string;
+
+}
+
+/**
+ * Converts an object of type 'Provider' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_Provider(obj: Provider | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'KeyArn': obj.keyArn,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema KubernetesApiAccessEntry
+ */
+export interface KubernetesApiAccessEntry {
+  /**
+   * @schema KubernetesApiAccessEntry#Arn
+   */
+  readonly arn?: string;
+
+  /**
+   * @schema KubernetesApiAccessEntry#Username
+   */
+  readonly username?: string;
+
+  /**
+   * @schema KubernetesApiAccessEntry#Groups
+   */
+  readonly groups?: string[];
+
+}
+
+/**
+ * Converts an object of type 'KubernetesApiAccessEntry' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_KubernetesApiAccessEntry(obj: KubernetesApiAccessEntry | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Arn': obj.arn,
+    'Username': obj.username,
+    'Groups': obj.groups?.map(y => y),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+"
+`;

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -286,6 +286,50 @@ export enum FqnOfTestTypeChildSecondEnum {
 "
 `;
 
+exports[`enums uses non-symbolic values 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * The SLO time window options. Allowed enum values: 7d,30d,90d
+   *
+   * @schema fqn.of.TestType#Timeframe
+   */
+  readonly timeframe?: FqnOfTestTypeTimeframe;
+
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Timeframe': obj.timeframe,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * The SLO time window options. Allowed enum values: 7d,30d,90d
+ *
+ * @schema FqnOfTestTypeTimeframe
+ */
+export enum FqnOfTestTypeTimeframe {
+  /** 7d */
+  VALUE_7D = '7d',
+  /** 30d */
+  VALUE_30D = '30d',
+  /** 90d */
+  VALUE_90D = '90d',
+}
+"
+`;
+
 exports[`enums without type implies "string" 1`] = `
 "/**
  * @schema fqn.of.TestType
@@ -323,411 +367,6 @@ export enum FqnOfTestTypeColor {
   /** blue */
   BLUE = 'blue',
 }
-"
-`;
-
-exports[`forStruct 1`] = `
-"/**
- * A resource that creates Amazon Elastic Kubernetes Service (Amazon EKS) clusters.
- *
- * @schema EksProps
- */
-export interface EksProps {
-  /**
-   * A unique name for your cluster.
-   *
-   * @schema EksProps#Name
-   */
-  readonly name?: string;
-
-  /**
-   * Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role. This provides permissions for Amazon EKS to call other AWS APIs.
-   *
-   * @schema EksProps#RoleArn
-   */
-  readonly roleArn: string;
-
-  /**
-   * Name of the AWS Identity and Access Management (IAM) role used for clusters that have the public endpoint disabled. this provides permissions for Lambda to be invoked and attach to the cluster VPC
-   *
-   * @schema EksProps#LambdaRoleName
-   */
-  readonly lambdaRoleName?: string;
-
-  /**
-   * Desired Kubernetes version for your cluster. If you don't specify this value, the cluster uses the latest version from Amazon EKS.
-   *
-   * @schema EksProps#Version
-   */
-  readonly version?: string;
-
-  /**
-   * Network configuration for Amazon EKS cluster.
-   *
-   *
-   *
-   * @schema EksProps#KubernetesNetworkConfig
-   */
-  readonly kubernetesNetworkConfig?: EksPropsKubernetesNetworkConfig;
-
-  /**
-   * An object that represents the virtual private cloud (VPC) configuration to use for an Amazon EKS cluster.
-   *
-   * @schema EksProps#ResourcesVpcConfig
-   */
-  readonly resourcesVpcConfig: EksPropsResourcesVpcConfig;
-
-  /**
-   * Enables exporting of logs from the Kubernetes control plane to Amazon CloudWatch Logs. By default, logs from the cluster control plane are not exported to CloudWatch Logs. The valid log types are api, audit, authenticator, controllerManager, and scheduler.
-   *
-   * @schema EksProps#EnabledClusterLoggingTypes
-   */
-  readonly enabledClusterLoggingTypes?: string[];
-
-  /**
-   * Encryption configuration for the cluster.
-   *
-   * @schema EksProps#EncryptionConfig
-   */
-  readonly encryptionConfig?: EncryptionConfigEntry[];
-
-  /**
-   * @schema EksProps#KubernetesApiAccess
-   */
-  readonly kubernetesApiAccess?: EksPropsKubernetesApiAccess;
-
-  /**
-   * ARN of the cluster (e.g., \`arn:aws:eks:us-west-2:666666666666:cluster/prod\`).
-   *
-   * @schema EksProps#Arn
-   */
-  readonly arn?: string;
-
-  /**
-   * Certificate authority data for your cluster.
-   *
-   * @schema EksProps#CertificateAuthorityData
-   */
-  readonly certificateAuthorityData?: string;
-
-  /**
-   * Security group that was created by Amazon EKS for your cluster. Managed-node groups use this security group for control-plane-to-data-plane communications.
-   *
-   * @schema EksProps#ClusterSecurityGroupId
-   */
-  readonly clusterSecurityGroupId?: string;
-
-  /**
-   * Endpoint for your Kubernetes API server (e.g., https://5E1D0CEXAMPLEA591B746AFC5AB30262.yl4.us-west-2.eks.amazonaws.com).
-   *
-   * @schema EksProps#Endpoint
-   */
-  readonly endpoint?: string;
-
-  /**
-   * ARN or alias of the customer master key (CMK).
-   *
-   * @schema EksProps#EncryptionConfigKeyArn
-   */
-  readonly encryptionConfigKeyArn?: string;
-
-  /**
-   * Issuer URL for the OpenID Connect identity provider.
-   *
-   * @schema EksProps#OIDCIssuerURL
-   */
-  readonly oidcIssuerUrl?: string;
-
-  /**
-   * @schema EksProps#Tags
-   */
-  readonly tags?: EksPropsTags[];
-
-}
-
-/**
- * Converts an object of type 'EksProps' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_EksProps(obj: EksProps | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'Name': obj.name,
-    'RoleArn': obj.roleArn,
-    'LambdaRoleName': obj.lambdaRoleName,
-    'Version': obj.version,
-    'KubernetesNetworkConfig': toJson_EksPropsKubernetesNetworkConfig(obj.kubernetesNetworkConfig),
-    'ResourcesVpcConfig': toJson_EksPropsResourcesVpcConfig(obj.resourcesVpcConfig),
-    'EnabledClusterLoggingTypes': obj.enabledClusterLoggingTypes?.map(y => y),
-    'EncryptionConfig': obj.encryptionConfig?.map(y => toJson_EncryptionConfigEntry(y)),
-    'KubernetesApiAccess': toJson_EksPropsKubernetesApiAccess(obj.kubernetesApiAccess),
-    'Arn': obj.arn,
-    'CertificateAuthorityData': obj.certificateAuthorityData,
-    'ClusterSecurityGroupId': obj.clusterSecurityGroupId,
-    'Endpoint': obj.endpoint,
-    'EncryptionConfigKeyArn': obj.encryptionConfigKeyArn,
-    'OIDCIssuerURL': obj.oidcIssuerUrl,
-    'Tags': obj.tags?.map(y => toJson_EksPropsTags(y)),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * Network configuration for Amazon EKS cluster.
- *
- *
- *
- * @schema EksPropsKubernetesNetworkConfig
- */
-export interface EksPropsKubernetesNetworkConfig {
-  /**
-   * Specify the range from which cluster services will receive IPv4 addresses.
-   *
-   * @schema EksPropsKubernetesNetworkConfig#ServiceIpv4Cidr
-   */
-  readonly serviceIpv4Cidr?: string;
-
-}
-
-/**
- * Converts an object of type 'EksPropsKubernetesNetworkConfig' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_EksPropsKubernetesNetworkConfig(obj: EksPropsKubernetesNetworkConfig | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'ServiceIpv4Cidr': obj.serviceIpv4Cidr,
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * An object that represents the virtual private cloud (VPC) configuration to use for an Amazon EKS cluster.
- *
- * @schema EksPropsResourcesVpcConfig
- */
-export interface EksPropsResourcesVpcConfig {
-  /**
-   * Specify one or more security groups for the cross-account elastic network interfaces that Amazon EKS creates to use to allow communication between your worker nodes and the Kubernetes control plane. If you don't specify a security group, the default security group for your VPC is used.
-   *
-   * @schema EksPropsResourcesVpcConfig#SecurityGroupIds
-   */
-  readonly securityGroupIds?: string[];
-
-  /**
-   * Specify subnets for your Amazon EKS worker nodes. Amazon EKS creates cross-account elastic network interfaces in these subnets to allow communication between your worker nodes and the Kubernetes control plane.
-   *
-   * @schema EksPropsResourcesVpcConfig#SubnetIds
-   */
-  readonly subnetIds: string[];
-
-  /**
-   * Set this value to false to disable public access to your cluster's Kubernetes API server endpoint. If you disable public access, your cluster's Kubernetes API server can only receive requests from within the cluster VPC. The default value for this parameter is true , which enables public access for your Kubernetes API server.
-   *
-   * @schema EksPropsResourcesVpcConfig#EndpointPublicAccess
-   */
-  readonly endpointPublicAccess?: boolean;
-
-  /**
-   * Set this value to true to enable private access for your cluster's Kubernetes API server endpoint. If you enable private access, Kubernetes API requests from within your cluster's VPC use the private VPC endpoint. The default value for this parameter is false , which disables private access for your Kubernetes API server. If you disable private access and you have worker nodes or AWS Fargate pods in the cluster, then ensure that publicAccessCidrs includes the necessary CIDR blocks for communication with the worker nodes or Fargate pods.
-   *
-   * @schema EksPropsResourcesVpcConfig#EndpointPrivateAccess
-   */
-  readonly endpointPrivateAccess?: boolean;
-
-  /**
-   * The CIDR blocks that are allowed access to your cluster's public Kubernetes API server endpoint. Communication to the endpoint from addresses outside of the CIDR blocks that you specify is denied. The default value is 0.0.0.0/0 . If you've disabled private endpoint access and you have worker nodes or AWS Fargate pods in the cluster, then ensure that you specify the necessary CIDR blocks.
-   *
-   * @schema EksPropsResourcesVpcConfig#PublicAccessCidrs
-   */
-  readonly publicAccessCidrs?: string[];
-
-}
-
-/**
- * Converts an object of type 'EksPropsResourcesVpcConfig' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_EksPropsResourcesVpcConfig(obj: EksPropsResourcesVpcConfig | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'SecurityGroupIds': obj.securityGroupIds?.map(y => y),
-    'SubnetIds': obj.subnetIds?.map(y => y),
-    'EndpointPublicAccess': obj.endpointPublicAccess,
-    'EndpointPrivateAccess': obj.endpointPrivateAccess,
-    'PublicAccessCidrs': obj.publicAccessCidrs?.map(y => y),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * The encryption configuration for the cluster.
- *
- * @schema EncryptionConfigEntry
- */
-export interface EncryptionConfigEntry {
-  /**
-   * Specifies the resources to be encrypted. The only supported value is \\"secrets\\".
-   *
-   * @schema EncryptionConfigEntry#Resources
-   */
-  readonly resources?: string[];
-
-  /**
-   * @schema EncryptionConfigEntry#Provider
-   */
-  readonly provider?: Provider;
-
-}
-
-/**
- * Converts an object of type 'EncryptionConfigEntry' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_EncryptionConfigEntry(obj: EncryptionConfigEntry | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'Resources': obj.resources?.map(y => y),
-    'Provider': toJson_Provider(obj.provider),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * @schema EksPropsKubernetesApiAccess
- */
-export interface EksPropsKubernetesApiAccess {
-  /**
-   * @schema EksPropsKubernetesApiAccess#Roles
-   */
-  readonly roles?: KubernetesApiAccessEntry[];
-
-  /**
-   * @schema EksPropsKubernetesApiAccess#Users
-   */
-  readonly users?: KubernetesApiAccessEntry[];
-
-}
-
-/**
- * Converts an object of type 'EksPropsKubernetesApiAccess' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_EksPropsKubernetesApiAccess(obj: EksPropsKubernetesApiAccess | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'Roles': obj.roles?.map(y => toJson_KubernetesApiAccessEntry(y)),
-    'Users': obj.users?.map(y => toJson_KubernetesApiAccessEntry(y)),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * @schema EksPropsTags
- */
-export interface EksPropsTags {
-  /**
-   * @schema EksPropsTags#Value
-   */
-  readonly value: string;
-
-  /**
-   * @schema EksPropsTags#Key
-   */
-  readonly key: string;
-
-}
-
-/**
- * Converts an object of type 'EksPropsTags' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_EksPropsTags(obj: EksPropsTags | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'Value': obj.value,
-    'Key': obj.key,
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * AWS Key Management Service (AWS KMS) customer master key (CMK). Either the ARN or the alias can be used.
- *
- * @schema Provider
- */
-export interface Provider {
-  /**
-   * Amazon Resource Name (ARN) or alias of the customer master key (CMK). The CMK must be symmetric, created in the same region as the cluster, and if the CMK was created in a different account, the user must have access to the CMK.
-   *
-   * @schema Provider#KeyArn
-   */
-  readonly keyArn?: string;
-
-}
-
-/**
- * Converts an object of type 'Provider' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_Provider(obj: Provider | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'KeyArn': obj.keyArn,
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * @schema KubernetesApiAccessEntry
- */
-export interface KubernetesApiAccessEntry {
-  /**
-   * @schema KubernetesApiAccessEntry#Arn
-   */
-  readonly arn?: string;
-
-  /**
-   * @schema KubernetesApiAccessEntry#Username
-   */
-  readonly username?: string;
-
-  /**
-   * @schema KubernetesApiAccessEntry#Groups
-   */
-  readonly groups?: string[];
-
-}
-
-/**
- * Converts an object of type 'KubernetesApiAccessEntry' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubernetesApiAccessEntry(obj: KubernetesApiAccessEntry | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'Arn': obj.arn,
-    'Username': obj.username,
-    'Groups': obj.groups?.map(y => y),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
 "
 `;
 

--- a/test/fixtures/aqua-enterprise-enforcer.json
+++ b/test/fixtures/aqua-enterprise-enforcer.json
@@ -1,0 +1,204 @@
+{
+  "typeName": "Aqua::Enterprise::Enforcer",
+  "description": "A resource provider for Aqua Enterprise Enforcer.",
+  "sourceUrl": "https://github.com/aquasecurity/aqua-helm.git",
+  "definitions": {
+    "Arn": {
+      "type": "string",
+      "pattern": "^arn:aws(-(cn|us-gov))?:[a-z-]+:(([a-z]+-)+[0-9])?:([0-9]{12})?:[^.]+$"
+    }
+  },
+  "properties": {
+    "ClusterID": {
+      "description": "EKS cluster name",
+      "type": "string"
+    },
+    "KubeConfig": {
+      "description": "Secrets Manager ARN for kubeconfig file",
+      "$ref": "#/definitions/Arn"
+    },
+    "RoleArn": {
+      "description": "IAM to use with EKS cluster authentication, if not resource execution role will be used",
+      "$ref": "#/definitions/Arn"
+    },
+    "Namespace": {
+      "description": "Namespace to use with helm. Created if doesn't exist and default will be used if not provided",
+      "type": "string"
+    },
+    "Name": {
+      "description": "Name for the helm release",
+      "type": "string"
+    },
+    "Values": {
+      "description": "Custom Values can optionally be specified",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^.+$": {
+          "type": "string"
+        }
+      }
+    },
+    "ValueYaml": {
+      "description": "String representation of a values.yaml file",
+      "type": "string"
+    },
+    "Version": {
+      "description": "Version can be specified, if not latest will be used",
+      "type": "string"
+    },
+    "ValueOverrideURL": {
+      "description": "Custom Value Yaml file can optionally be specified",
+      "type": "string",
+      "pattern": "^[sS]3://[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z])(:[0-9]*)*([?/#].*)?$"
+    },
+    "ID": {
+      "description": "Primary identifier for Cloudformation",
+      "type": "string"
+    },
+    "TimeOut": {
+      "description": "Timeout for resource provider. Default 60 mins",
+      "type": "integer"
+    },
+    "VPCConfiguration": {
+      "type": "object",
+      "description": "For network connectivity to Cluster inside VPC",
+      "additionalProperties": false,
+      "properties": {
+        "SecurityGroupIds": {
+          "description": "Specify one or more security groups",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "SubnetIds": {
+          "description": "Specify one or more subnets",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "readOnlyProperties": [
+    "/properties/Resources",
+    "/properties/ID"
+  ],
+  "primaryIdentifier": [
+    "/properties/ID"
+  ],
+  "createOnlyProperties": [
+    "/properties/Name",
+    "/properties/Namespace",
+    "/properties/ClusterID"
+  ],
+  "handlers": {
+    "create": {
+      "permissions": [
+        "secretsmanager:GetSecretValue",
+        "kms:Decrypt",
+        "eks:DescribeCluster",
+        "s3:GetObject",
+        "sts:AssumeRole",
+        "iam:PassRole",
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "lambda:UpdateFunctionConfiguration",
+        "lambda:DeleteFunction",
+        "lambda:GetFunction",
+        "lambda:InvokeFunction",
+        "lambda:CreateFunction",
+        "lambda:UpdateFunctionCode"
+      ]
+    },
+    "read": {
+      "permissions": [
+        "secretsmanager:GetSecretValue",
+        "kms:Decrypt",
+        "eks:DescribeCluster",
+        "s3:GetObject",
+        "sts:AssumeRole",
+        "iam:PassRole",
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "lambda:UpdateFunctionConfiguration",
+        "lambda:DeleteFunction",
+        "lambda:GetFunction",
+        "lambda:InvokeFunction",
+        "lambda:CreateFunction",
+        "lambda:UpdateFunctionCode"
+      ]
+    },
+    "update": {
+      "permissions": [
+        "secretsmanager:GetSecretValue",
+        "kms:Decrypt",
+        "eks:DescribeCluster",
+        "s3:GetObject",
+        "sts:AssumeRole",
+        "iam:PassRole",
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "lambda:UpdateFunctionConfiguration",
+        "lambda:DeleteFunction",
+        "lambda:GetFunction",
+        "lambda:InvokeFunction",
+        "lambda:CreateFunction",
+        "lambda:UpdateFunctionCode"
+      ]
+    },
+    "delete": {
+      "permissions": [
+        "secretsmanager:GetSecretValue",
+        "kms:Decrypt",
+        "eks:DescribeCluster",
+        "s3:GetObject",
+        "sts:AssumeRole",
+        "iam:PassRole",
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "lambda:UpdateFunctionConfiguration",
+        "lambda:DeleteFunction",
+        "lambda:GetFunction",
+        "lambda:InvokeFunction",
+        "lambda:CreateFunction",
+        "lambda:UpdateFunctionCode"
+      ]
+    }
+  }
+}

--- a/test/fixtures/datadog.json
+++ b/test/fixtures/datadog.json
@@ -1,0 +1,210 @@
+{
+  "typeName": "Datadog::SLOs::SLO",
+  "description": "Datadog SLO 1.0.0",
+  "typeConfiguration": {
+    "properties": {
+      "DatadogCredentials": {
+        "$ref": "#/definitions/DatadogCredentials"
+      }
+    },
+    "additionalProperties": false
+  },
+  "definitions": {
+    "Creator": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Name": {
+          "description": "Name of the creator of the slo",
+          "type": "string"
+        },
+        "Handle": {
+          "description": "Handle of the creator of the slo",
+          "type": "string"
+        },
+        "Email": {
+          "description": "Email of the creator of the slo",
+          "type": "string"
+        }
+      }
+    },
+    "Threshold": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Target": {
+          "description": "The target value for the service level indicator within the corresponding timeframe.",
+          "type": "number"
+        },
+        "TargetDisplay": {
+          "description": "A string representation of the target that indicates its precision.(e.g. 98.00)",
+          "type": "string"
+        },
+        "Timeframe": {
+          "description": "The SLO time window options. Allowed enum values: 7d,30d,90d",
+          "type": "string",
+          "enum": [
+            "7d",
+            "30d",
+            "90d"
+          ]
+        },
+        "Warning": {
+          "description": "The warning value for the service level objective.",
+          "type": "number"
+        },
+        "WarningDisplay": {
+          "description": "A string representation of the warning target.(e.g. 98.00)",
+          "type": "string"
+        }
+      }
+    },
+    "Query": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Numerator": {
+          "description": "A Datadog metric query for total (valid) events.",
+          "type": "string"
+        },
+        "Denominator": {
+          "description": "A Datadog metric query for good events.",
+          "type": "string"
+        }
+      }
+    },
+    "DatadogCredentials": {
+      "description": "Credentials for the Datadog API",
+      "properties": {
+        "ApiKey": {
+          "description": "Datadog API key",
+          "type": "string"
+        },
+        "ApplicationKey": {
+          "description": "Datadog application key",
+          "type": "string"
+        },
+        "ApiURL": {
+          "description": "Datadog API URL (defaults to https://api.datadoghq.com) Use https://api.datadoghq.eu for EU accounts.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ApiKey",
+        "ApplicationKey"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "Creator": {
+      "$ref": "#/definitions/Creator"
+    },
+    "Description": {
+      "description": "Description of the slo",
+      "type": "string"
+    },
+    "Groups": {
+      "description": "A list of (up to 20) monitor groups that narrow the scope of a monitor service level objective.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "Id": {
+      "description": "ID of the slo",
+      "type": "string"
+    },
+    "MonitorIds": {
+      "description": "A list of monitor ids that defines the scope of a monitor service level objective. Required if type is monitor.",
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "Name": {
+      "description": "Name of the slo",
+      "type": "string"
+    },
+    "Query": {
+      "$ref": "#/definitions/Query"
+    },
+    "Tags": {
+      "description": "Tags associated with the slo",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "Thresholds": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Threshold"
+      }
+    },
+    "Type": {
+      "type": "string",
+      "description": "The type of the slo",
+      "enum": [
+        "monitor",
+        "metric"
+      ]
+    },
+    "Created": {
+      "description": "Date of creation of the slo",
+      "type": "string",
+      "format": "date-time"
+    },
+    "Deleted": {
+      "description": "Date of deletion of the slo",
+      "type": "string",
+      "format": "date-time"
+    },
+    "Modified": {
+      "description": "Date of modification of the slo",
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "Name",
+    "Thresholds",
+    "Type"
+  ],
+  "primaryIdentifier": [
+    "/properties/Id"
+  ],
+  "readOnlyProperties": [
+    "/properties/Modified",
+    "/properties/Id",
+    "/properties/Deleted",
+    "/properties/State",
+    "/properties/OverallState",
+    "/properties/Creator",
+    "/properties/Created"
+  ],
+  "additionalProperties": false,
+  "handlers": {
+    "create": {
+      "permissions": [
+        ""
+      ]
+    },
+    "read": {
+      "permissions": [
+        ""
+      ]
+    },
+    "update": {
+      "permissions": [
+        ""
+      ]
+    },
+    "delete": {
+      "permissions": [
+        ""
+      ]
+    }
+  }
+}

--- a/test/integ.test.ts
+++ b/test/integ.test.ts
@@ -1,0 +1,13 @@
+import { readdirSync, readFileSync } from 'fs';
+import * as path from 'path';
+import { TypeGenerator } from '../src';
+import { generate } from './util';
+
+jest.setTimeout(1000 * 60 * 5);
+
+test.each(readdirSync(path.join(__dirname, 'fixtures')))('generate struct for %s', async file => {
+  const schema = JSON.parse(readFileSync(path.join(__dirname, 'fixtures', file), 'utf-8'));
+  const gen = TypeGenerator.forStruct('MyStruct', schema);
+  const source = await generate(gen);
+  expect(source).toMatchSnapshot();
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,23 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { srcmak } from 'jsii-srcmak';
+import { TypeGenerator } from '../src';
+
+export async function generate(gen: TypeGenerator) {
+  const source = gen.render();
+  const deps = ['@types/node'].map(d => path.dirname(require.resolve(`${d}/package.json`)));
+
+  // check that the output compiles & is jsii-compatible
+  await mkdtemp(async workdir => {
+    await fs.writeFile(path.join(workdir, 'index.ts'), source);
+    await srcmak(workdir, { deps });
+  });
+
+  return source;
+}
+
+async function mkdtemp(closure: (dir: string) => Promise<void>) {
+  const workdir = await fs.mkdtemp(path.join(os.tmpdir(), 'cdk8s-'));
+  await closure(workdir);
+}


### PR DESCRIPTION
If an starts with a non-alpha character, we now prefix the member name with `VALUE_` so it can be used as a symbol.

Split up "integration tests" to a separate test so its easy to add cases by just dropping files under `fixtures/`.