### PR TITLE
feat: support numeric enums

### DIFF
--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -421,9 +421,9 @@ export function toJson_Threshold(obj: Threshold | undefined): Record<string, any
  */
 export enum MyStructType {
   /** monitor */
-  MONITOR = 'monitor',
+  MONITOR = \\"monitor\\",
   /** metric */
-  METRIC = 'metric',
+  METRIC = \\"metric\\",
 }
 
 /**
@@ -433,11 +433,11 @@ export enum MyStructType {
  */
 export enum ThresholdTimeframe {
   /** 7d */
-  VALUE_7D = '7d',
+  VALUE_7D = \\"7d\\",
   /** 30d */
-  VALUE_30D = '30d',
+  VALUE_30D = \\"30d\\",
   /** 90d */
-  VALUE_90D = '90d',
+  VALUE_90D = \\"90d\\",
 }
 "
 `;

--- a/test/__snapshots__/tojson.test.ts.snap
+++ b/test/__snapshots__/tojson.test.ts.snap
@@ -270,11 +270,11 @@ export function toJson_MyStruct(obj: MyStruct | undefined): Record<string, any> 
  */
 export enum MyStructMyEnum {
   /** one */
-  ONE = 'one',
+  ONE = \\"one\\",
   /** two */
-  TWO = 'two',
+  TWO = \\"two\\",
   /** three */
-  THREE = 'three',
+  THREE = \\"three\\",
 }
 
 /**
@@ -282,9 +282,9 @@ export enum MyStructMyEnum {
  */
 export enum MyStructYourEnum {
   /** jo */
-  JO = 'jo',
+  JO = \\"jo\\",
   /** shmo */
-  SHMO = 'shmo',
+  SHMO = \\"shmo\\",
 }
 "
 `;

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -193,6 +193,86 @@ export function toJson_TestType(obj: TestType | undefined): Record<string, any> 
 "
 `;
 
+exports[`enums has integer values 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#Days
+   */
+  readonly days?: FqnOfTestTypeDays;
+
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Days': obj.days,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema FqnOfTestTypeDays
+ */
+export enum FqnOfTestTypeDays {
+  /** 1 */
+  VALUE_1 = 1,
+  /** 2 */
+  VALUE_2 = 2,
+  /** 3 */
+  VALUE_3 = 3,
+}
+"
+`;
+
+exports[`enums has number values 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#Percentiles
+   */
+  readonly percentiles?: FqnOfTestTypePercentiles;
+
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Percentiles': obj.percentiles,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema FqnOfTestTypePercentiles
+ */
+export enum FqnOfTestTypePercentiles {
+  /** 0.9 */
+  VALUE_0_9 = 0.9,
+  /** 0.95 */
+  VALUE_0_95 = 0.95,
+  /** 0.99 */
+  VALUE_0_99 = 0.99,
+}
+"
+`;
+
 exports[`enums renders a typescript enum 1`] = `
 "/**
  * @schema fqn.of.TestType
@@ -234,13 +314,13 @@ export function toJson_TestType(obj: TestType | undefined): Record<string, any> 
  */
 export enum FqnOfTestTypeFirstEnum {
   /** value1 */
-  VALUE1 = 'value1',
+  VALUE1 = \\"value1\\",
   /** value2 */
-  VALUE2 = 'value2',
+  VALUE2 = \\"value2\\",
   /** value-of-three */
-  VALUE_OF_THREE = 'value-of-three',
+  VALUE_OF_THREE = \\"value-of-three\\",
   /** valueOfFour */
-  VALUE_OF_FOUR = 'valueOfFour',
+  VALUE_OF_FOUR = \\"valueOfFour\\",
 }
 
 /**
@@ -277,11 +357,11 @@ export function toJson_FqnOfTestTypeChild(obj: FqnOfTestTypeChild | undefined): 
  */
 export enum FqnOfTestTypeChildSecondEnum {
   /** hey */
-  HEY = 'hey',
+  HEY = \\"hey\\",
   /** enum values can be crazy */
-  ENUM_VALUES_CAN_BE_CRAZY = 'enum values can be crazy',
+  ENUM_VALUES_CAN_BE_CRAZY = \\"enum values can be crazy\\",
   /** yes>>123 */
-  YES_123 = 'yes>>123',
+  YES_123 = \\"yes>>123\\",
 }
 "
 `;
@@ -321,11 +401,11 @@ export function toJson_TestType(obj: TestType | undefined): Record<string, any> 
  */
 export enum FqnOfTestTypeTimeframe {
   /** 7d */
-  VALUE_7D = '7d',
+  VALUE_7D = \\"7d\\",
   /** 30d */
-  VALUE_30D = '30d',
+  VALUE_30D = \\"30d\\",
   /** 90d */
-  VALUE_90D = '90d',
+  VALUE_90D = \\"90d\\",
 }
 "
 `;
@@ -361,11 +441,11 @@ export function toJson_TestType(obj: TestType | undefined): Record<string, any> 
  */
 export enum FqnOfTestTypeColor {
   /** red */
-  RED = 'red',
+  RED = \\"red\\",
   /** green */
-  GREEN = 'green',
+  GREEN = \\"green\\",
   /** blue */
-  BLUE = 'blue',
+  BLUE = \\"blue\\",
 }
 "
 `;

--- a/test/__snapshots__/usage.test.ts.snap
+++ b/test/__snapshots__/usage.test.ts.snap
@@ -82,13 +82,13 @@ export function toJson_Name(obj: Name | undefined): Record<string, any> | undefi
  */
 export enum PersonFavoriteColor {
   /** red */
-  RED = 'red',
+  RED = \\"red\\",
   /** green */
-  GREEN = 'green',
+  GREEN = \\"green\\",
   /** blue */
-  BLUE = 'blue',
+  BLUE = \\"blue\\",
   /** yellow */
-  YELLOW = 'yellow',
+  YELLOW = \\"yellow\\",
 }
 "
 `;

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -274,6 +274,32 @@ describe('enums', () => {
       },
     },
   });
+
+  which('has number values', {
+    properties: {
+      Percentiles: {
+        type: 'number',
+        enum: [
+          .9,
+          .95,
+          .99,
+        ],
+      },
+    },
+  });
+
+  which('has integer values', {
+    properties: {
+      Days: {
+        type: 'integer',
+        enum: [
+          1,
+          2,
+          3,
+        ],
+      },
+    },
+  });
 });
 
 which('primitives', {


### PR DESCRIPTION
Fixes `Error: only "string" enums are supported` when trying to convert `GitHub::Repositories::Webhook`.

The respective Schema section looks like this:
```
    "InsecureSsl": {
      "description": "Determines whether the SSL certificate of the host for url will be verified when delivering payloads. Supported values include 0 (verification is performed) and 1 (verification is not performed). The default is 0. We strongly recommend not setting this to 1 as you are subject to man-in-the-middle and other attacks.",
      "type": "number",
      "default": 0,
      "enum": [
        0,
        1
      ]
    }
```

While this doesn't make a whole lot of sense, JsonSchema allows numeric enum values. 