### PR TITLE
fix!: kebab-cases type names not correctly converted to PascalCase

### DIFF
--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -72,12 +72,16 @@ export class TypeGenerator {
    * (e.g. "Vpc", "FooBarZooFiGoo").
    */
   public static normalizeTypeName(typeName: string) {
+
+    // Handle kebab-case first
+    const stage1 = typeName.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join('');
+
     // start with the full string and then use the regex to match all-caps sequences.
     const re = /([A-Z]+)(?:[^a-z]|$)/g;
-    let result = typeName;
+    let result = stage1;
     let m;
     do {
-      m = re.exec(typeName);
+      m = re.exec(stage1);
       if (m) {
         const before = result.slice(0, m.index); // all the text before the sequence
         const cap = m[1]; // group #1 matches the all-caps sequence we are after

--- a/test/type-generator.naming.test.ts
+++ b/test/type-generator.naming.test.ts
@@ -22,4 +22,12 @@ describe('normalizeTypeName', () => {
     expect(TypeGenerator.normalizeTypeName('attributemanifestsOptions')).toEqual('AttributemanifestsOptions');
     expect(TypeGenerator.normalizeTypeName('attributeMANIFESTSOptions')).toEqual('AttributeManifestsOptions');
   });
+  test('Kebab-case names are converted to PascalCase', () => {
+    expect(TypeGenerator.normalizeTypeName('AttributeManifests')).toEqual('AttributeManifests');
+    expect(TypeGenerator.normalizeTypeName('Attribute-Manifests')).toEqual('AttributeManifests');
+    expect(TypeGenerator.normalizeTypeName('Attribute-manifests')).toEqual('AttributeManifests');
+    expect(TypeGenerator.normalizeTypeName('attribute-manifests')).toEqual('AttributeManifests');
+    expect(TypeGenerator.normalizeTypeName('attribute-manifestsOptions')).toEqual('AttributeManifestsOptions');
+    expect(TypeGenerator.normalizeTypeName('attribute-MANIFESTSOptions')).toEqual('AttributeManifestsOptions');
+  });
 });


### PR DESCRIPTION
In kebab-case, the dash character is supposed to separate words, which is currently not reflected in `normalizeTypeName`. Currently, kebab-cased type names like "name-type" are converted to "Nametype" instead of more expected "NameType". This patch adds a pre-processing step which handles kebab-case first.

BREAKING CHANGE: kebab-cased type names like `name-type` were converted to `Nametype`. Now they are converted to `NameType`.