### PR TITLE
fix: same values but different casing creates conflicting enums

### DIFF
--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -521,7 +521,7 @@ export class TypeGenerator {
 
       code.openBlock(`export enum ${typeName}`);
 
-      const processedValues: string[] = [];
+      const processedValues = new Set<string>();
 
       for (const value of def.enum) {
         if (!['string', 'number'].includes(typeof(value))) {
@@ -534,8 +534,8 @@ export class TypeGenerator {
         // If enums of same value exists, then we choose one of them and skip adding others
         // since that would cause conflict
         const lowerCaseValue = value?.toString().toLowerCase();
-        if (lowerCaseValue && !processedValues.includes(lowerCaseValue)) {
-          processedValues.push(lowerCaseValue);
+        if (lowerCaseValue && !processedValues.has(lowerCaseValue)) {
+          processedValues.add(lowerCaseValue);
         } else {
           continue;
         }

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -521,6 +521,8 @@ export class TypeGenerator {
 
       code.openBlock(`export enum ${typeName}`);
 
+      const processedValues: string[] = [];
+
       for (const value of def.enum) {
         if (!['string', 'number'].includes(typeof(value))) {
           throw new Error('only enums with string or number values are supported');
@@ -528,6 +530,15 @@ export class TypeGenerator {
 
         // sluggify and turn to UPPER_SNAKE_CASE
         let memberName = snakeCase(`${value}`.replace(/[^a-z0-9]/gi, '_')).split('_').filter(x => x).join('_').toUpperCase();
+
+        // If enums of same value exists, then we choose one of them and skip adding others
+        // since that would cause conflict
+        const lowerCaseValue = value?.toString().toLowerCase();
+        if (lowerCaseValue && !processedValues.includes(lowerCaseValue)) {
+          processedValues.push(lowerCaseValue);
+        } else {
+          continue;
+        }
 
         // if member name starts with a non-alpha character, add a prefix so it becomes a symbol
         if (!/^[A-Z].*/i.test(memberName)) {

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -311,6 +311,52 @@ export enum FqnOfTestTypePercentiles {
 "
 `;
 
+exports[`enums has repeated values 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#Same
+   */
+  readonly same?: FqnOfTestTypeSame;
+
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'Same': obj.same,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema FqnOfTestTypeSame
+ */
+export enum FqnOfTestTypeSame {
+  /** replace */
+  REPLACE = \\"replace\\",
+  /** keep */
+  KEEP = \\"keep\\",
+  /** hashmod */
+  HASHMOD = \\"hashmod\\",
+  /** labelmap */
+  LABELMAP = \\"labelmap\\",
+  /** 24 */
+  VALUE_24 = \\"24\\",
+  /** 0.99 */
+  VALUE_0_99 = \\"0.99\\",
+}
+"
+`;
+
 exports[`enums renders a typescript enum 1`] = `
 "/**
  * @schema fqn.of.TestType

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -300,6 +300,26 @@ describe('enums', () => {
       },
     },
   });
+
+  which('has repeated values', {
+    properties: {
+      Same: {
+        type: 'string',
+        enum: [
+          'replace',
+          'Replace',
+          'keep',
+          'Keep',
+          'hashmod',
+          'HashMod',
+          'labelmap',
+          'LabelMap',
+          '24',
+          '0.99',
+        ],
+      },
+    },
+  });
 });
 
 which('primitives', {


### PR DESCRIPTION
Enums in schema which has same value but different casing creates same enum values which conflicts with each other. For instance, [observed](https://github.com/cdk8s-team/cdk8s-cli/issues/578#issuecomment-1559646717) while importing a custom resource definition in cdk8s.

```
\| 1086   REPLACE = 'replace',
--
\|        ~~~~~~~
\| com.coreos.monitoring.ts:1088:3 - error TS2300: Duplicate identifier 'REPLACE'.
\| 1088   REPLACE = 'Replace',
\|        ~~~~~~~
\| com.coreos.monitoring.ts:1090:3 - error TS2300: Duplicate identifier 'KEEP'.
\| 1090   KEEP = 'keep',
\|        ~~~~
\| com.coreos.monitoring.ts:1092:3 - error TS2300: Duplicate identifier 'KEEP'.
\| 1092   KEEP = 'Keep',
\|        ~~~~
\| com.coreos.monitoring.ts:1094:3 - error TS2300: Duplicate identifier 'DROP'.
\| 1094   DROP = 'drop',
\|        ~~~~
\| com.coreos.monitoring.ts:1096:3 - error TS2300: Duplicate identifier 'DROP'.
\| 1096   DROP = 'Drop',
```

Fixes https://github.com/cdk8s-team/cdk8s-cli/issues/578