### PR TITLE
Convert slashes in property names to underscores

### DIFF
--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -488,6 +488,9 @@ export class TypeGenerator {
       name = name.substring(1);
     }
 
+    // Replace slashes with underscores (for property names liks 'kubernetes/io')
+    name = name.replace(/\//, '_');
+
     // convert the name to camel case so it's compatible with JSII
     name = camelCase(name);
 

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -926,6 +926,34 @@ export function toJson_ItemType(obj: ItemType | undefined): Record<string, any> 
 "
 `;
 
+exports[`structs converts field names with slashes correctly 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#kubernetes/io
+   */
+  readonly kubernetesIo: string;
+
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'kubernetes/io': obj.kubernetesIo,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+"
+`;
+
 exports[`structs has a field that references another struct (with required fields) 1`] = `
 "/**
  * @schema fqn.of.TestType

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -187,6 +187,19 @@ describe('structs', () => {
     },
   });
 
+  which('converts field names with slashes correctly', {
+    required: [
+      'kubernetes/io',
+    ],
+    type: 'object',
+    properties: {
+      'kubernetes/io': {
+        description: '',
+        type: 'string',
+      },
+    },
+  });
+
   which('if we have "properties" and "type" is omitted, it is considered a struct', {
     properties: {
       foo: {


### PR DESCRIPTION
Some schemas contain property names like `kubernetes/io`, which have been re-used as is, e.g. `readonly kubernetes/io: string;`. This patch converts the slashes to underscores, so that the usual camel-case conversion to `kubernetesIo` can take place.