### PR TITLE
chore: fixing failing release workflow

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -9,7 +9,7 @@ const project = new CdklabsTypeScriptProject({
   description: 'Generates jsii structs from JSON schemas',
   authorName: 'Elad Ben-Israel',
   authorEmail: 'elad.benisrael@gmail.com',
-  repository: 'https://github.com/aws/json2jsii.git',
+  repository: 'https://github.com/aws/json2jsii',
   deps: ['json-schema', 'camelcase', 'snake-case'],
   devDeps: ['@types/json-schema', 'jsii-srcmak', 'prettier', 'cdklabs-projen-project-types'],
   releaseToNpm: true,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Generates jsii structs from JSON schemas",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aws/json2jsii.git"
+    "url": "https://github.com/aws/json2jsii"
   },
   "scripts": {
     "build": "npx projen build",


### PR DESCRIPTION
```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/json2jsii
Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/aws/json2jsii.git", expected to match "https://github.com/cdklabs/json2jsii" from provenance
```
