### PR TITLE
fix: duplicate properties emitted when they differ only by casing

### DIFF
--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -119,6 +119,34 @@ export function toJson_V1beta1Foo(obj: V1beta1Foo | undefined): Record<string, a
 "
 `;
 
+exports[`dedup properties with different casing 1`] = `
+"/**
+ * @schema Foo
+ */
+export interface Foo {
+  /**
+   * @schema Foo#pod_priority_class_name
+   */
+  readonly podPriorityClassName?: string;
+
+}
+
+/**
+ * Converts an object of type 'Foo' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_Foo(obj: Foo | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'pod_priority_class_name': obj.podPriorityClassName,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+"
+`;
+
 exports[`documentation "*/" is is escaped 1`] = `
 "/**
  * @schema fqn.of.TestType

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -601,3 +601,25 @@ function which(name: string, schema: JSONSchema4, definitions?: JSONSchema4) {
     expect(await generate(gen)).toMatchSnapshot();
   });
 }
+
+test('dedup properties with different casing', async () => {
+
+  // based on https://github.com/zalando/postgres-operator/blob/7d4da928726b5029f72e9ab83ee9b6ff481e70c7/manifests/postgresql.crd.yaml#L353-L357
+  const schema: JSONSchema4 = {
+    properties: {
+      pod_priority_class_name: {
+        type: 'string',
+      },
+      podPriorityClassName: {
+        type: 'string',
+      },
+    },
+  };
+
+  const gen = TypeGenerator.forStruct('Foo', schema, {
+    toJson: true,
+  });
+
+  expect(await generate(gen)).toMatchSnapshot();
+
+});


### PR DESCRIPTION
Required for https://github.com/cdk8s-team/cdk8s-cli/issues/2722

Even though we arbitrarily choose which property to emit, this is not a breaking change because these scenarios right now produce invalid typescript code. 

> This is similar to and a continuation of https://github.com/cdklabs/json2jsii/pull/1259

---

### Ask Yourself

- [x] Have you reviewed the [contribution guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md)?
- [x] Have you reviewed the [breaking changes guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md#breaking-changes)?
