### PR TITLE
feat: Emit regex validation for properties

### DIFF
--- a/src/tojson.ts
+++ b/src/tojson.ts
@@ -1,12 +1,16 @@
 import { Code } from './code';
 
+export interface ObjectField {
+  renderedField: string;
+  propertyRegex?: string;
+}
 export class ToJsonFunction {
   /**
    * The name the toJson function for a struct.
    */
   public readonly functionName: string;
 
-  private readonly fields: Record<string, string> = {};
+  private readonly fields: Record<string, ObjectField> = {};
 
   constructor(private readonly baseType: string) {
     this.functionName = `toJson_${baseType}`;
@@ -20,8 +24,11 @@ export class ToJsonFunction {
    * @param toJson A function used to convert a value from JavaScript to schema
    * format. This could be `x => x` if no conversion is required.
    */
-  public addField(schemaName: string, propertyName: string, toJson: ToJson) {
-    this.fields[schemaName] = toJson(`obj.${propertyName}`);
+  public addField(schemaName: string, propertyName: string, toJson: ToJson, propertyRegex?: string) {
+    this.fields[schemaName]= <ObjectField>{
+      renderedField: toJson(`obj.${propertyName}`),
+      propertyRegex: propertyRegex,
+    };
   }
 
   public emit(code: Code) {
@@ -35,12 +42,20 @@ export class ToJsonFunction {
 
     code.open('const result = {');
     for (const [k, v] of Object.entries(this.fields)) {
-      code.line(`'${k}': ${v},`);
+      code.line(`'${k}': ${v.renderedField},`);
     }
     code.close('};');
 
     code.line('// filter undefined values');
     code.line('return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});');
+
+    for (const [k, v] of Object.entries(this.fields)) {
+      if (v.propertyRegex) {
+        code.open(`if (result['${k}'] !== undefined && !(new RegExp('${v.propertyRegex}').test(result['${k}']!))) {`);
+        code.line(`throw new Error('property ${k} does not match validation regex ${v.propertyRegex}')`);
+        code.close('};');
+      }
+    };
 
     code.closeBlock();
     code.line('/* eslint-enable max-len, quote-props */');

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -415,14 +415,14 @@ export class TypeGenerator {
    * @returns true if this definition can be represented as a union or false if it cannot
    */
   private tryEmitUnion(typeName: string, def: JSONSchema4, fqn: string): EmittedType | undefined {
-    const options = new Array<string>();
+    const options = new Array<[string, string?]>();
     for (const option of def.oneOf || def.anyOf || []) {
       if (!supportedUnionOptionType(option.type)) {
         return undefined;
       }
 
       const type = option.type === 'integer' ? 'number' : option.type;
-      options.push(type);
+      options.push([type, option.pattern]);
     }
 
     const emitted: EmittedType = { type: typeName, toJson: x => `${x}?.value` };
@@ -433,10 +433,16 @@ export class TypeGenerator {
       code.openBlock(`export class ${typeName}`);
       const possibleTypes = [];
 
-      for (const type of options) {
+      for (const [type, pattern] of options) {
         possibleTypes.push(type);
         const methodName = 'from' + type[0].toUpperCase() + type.substr(1);
         code.openBlock(`public static ${methodName}(value: ${type}): ${typeName}`);
+        if (pattern) {
+          code.open(`if (!(new RegExp('${pattern}').test(value))) {`);
+          code.line(`throw new Error(\`value \${value} does not match validation regex ${pattern}\`)`);
+          code.close('};');
+        };
+
         code.line(`return new ${typeName}(value);`);
         code.closeBlock();
       }
@@ -512,7 +518,7 @@ export class TypeGenerator {
     code.line(`readonly ${name}${optional}: ${propertyType.type};`);
     code.line();
 
-    toJson.addField(originalName, name, propertyType.toJson);
+    toJson.addField(originalName, name, propertyType.toJson, propDef.pattern);
     this.emittedProperties.add(propertyFqn);
   }
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -115,6 +115,9 @@ export function toJson_MyStruct(obj: MyStruct | undefined): Record<string, any> 
   };
   // filter undefined values
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+  if (result['ValueOverrideURL'] !== undefined && !(new RegExp('^[sS]3://[0-9a-zA-Z]([-.\\\\w]*[0-9a-zA-Z])(:[0-9]*)*([?/#].*)?$').test(result['ValueOverrideURL']!))) {
+    throw new Error('property ValueOverrideURL does not match validation regex ^[sS]3://[0-9a-zA-Z]([-.\\\\w]*[0-9a-zA-Z])(:[0-9]*)*([?/#].*)?$')
+  };
 }
 /* eslint-enable max-len, quote-props */
 
@@ -844,5 +847,50 @@ export function toJson_KubernetesApiAccessEntry(obj: KubernetesApiAccessEntry | 
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+"
+`;
+
+exports[`generate struct for timeoutschema.json 1`] = `
+"/**
+ * @schema config
+ */
+export interface Config {
+  /**
+   * @schema config#timeout
+   */
+  readonly timeout?: ConfigTimeout;
+
+}
+
+/**
+ * Converts an object of type 'Config' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_Config(obj: Config | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'timeout': obj.timeout?.value,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema ConfigTimeout
+ */
+export class ConfigTimeout {
+  public static fromString(value: string): ConfigTimeout {
+    if (!(new RegExp('^[0-9]+(ns|us|µs|μs|ms|s|m|h)?$').test(value))) {
+      throw new Error(\`value \${value} does not match validation regex ^[0-9]+(ns|us|µs|μs|ms|s|m|h)?$\`)
+    };
+    return new ConfigTimeout(value);
+  }
+  public static fromNumber(value: number): ConfigTimeout {
+    return new ConfigTimeout(value);
+  }
+  private constructor(public readonly value: string | number) {
+  }
+}
 "
 `;

--- a/test/fixtures/timeoutschema.json
+++ b/test/fixtures/timeoutschema.json
@@ -1,0 +1,20 @@
+{
+  "$ref": "#/definitions/config",
+  "definitions": {
+    "config": {
+      "properties": {
+        "timeout": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9]+(ns|us|µs|μs|ms|s|m|h)?$"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds pattern validation for structs and enums. Struct validation is handled in the `toJson` function, and enums are checked at construction time.


