### PR TITLE
feat: (opt-in) unions with null are just optional types

### DIFF
--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,3 +1,4 @@
 export * from './null-in-type-array';
+export * from './null-in-union';
 export * from './union-duplicates';
 export * from './singleton-unions';

--- a/src/transformers/null-in-union.ts
+++ b/src/transformers/null-in-union.ts
@@ -1,0 +1,47 @@
+import { JSONSchema4 } from 'json-schema';
+
+/**
+ * Schemas may define a type as a union of types with one of the types being `null`.
+ * This is the same as defining an optional type.
+ */
+function removeNull(def: JSONSchema4, combinator: 'anyOf' | 'oneOf'): JSONSchema4 {
+  const union = def[combinator];
+  if (!(union && Array.isArray(union))) {
+    return def;
+  }
+
+  const nullType = union.some(t => t.type === 'null');
+  const nonNullTypes = new Set(union.filter(t => t.type !== 'null'));
+
+  if (nullType) {
+    def.required = false;
+  }
+
+  if (nonNullTypes.size === 0) {
+    def[combinator] = [{ type: 'null' }];
+  } else {
+    // if its a union of non null types we just drop null
+    def[combinator] = Array.from(nonNullTypes);
+  }
+
+  return def;
+}
+
+
+/**
+ * Many schemas define a type as an array of types to indicate union types.
+ * To avoid having the type generator be aware of that, we transform those types
+ * into their corresponding typescript definitions.
+ *
+ * --------------------------------------------------
+ *
+ * The null union can be in one of these three fields: type, anyOf or oneOf
+ */
+export function reduceNullFromUnions(def: JSONSchema4): JSONSchema4 {
+  const transformers: Array<(definition: JSONSchema4) => JSONSchema4> = [
+    (d: JSONSchema4) => removeNull(d, 'anyOf'),
+    (d: JSONSchema4) => removeNull(d, 'oneOf'),
+  ];
+
+  return transformers.reduce((input, transform) => transform(input), def);
+}

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -1371,6 +1371,94 @@ export function toJson_TestType(obj: TestType | undefined): Record<string, any> 
 "
 `;
 
+exports[`unions are tuples with a null type convertNullUnionsToOptional disabled 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#foo
+   */
+  readonly foo?: any;
+
+  /**
+   * @schema fqn.of.TestType#bar
+   */
+  readonly bar?: any;
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'foo': obj.foo,
+    'bar': obj.bar,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+"
+`;
+
+exports[`unions are tuples with a null type convertNullUnionsToOptional enabled 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#foo
+   */
+  readonly foo?: FqnOfTestTypeFoo;
+
+  /**
+   * @schema fqn.of.TestType#bar
+   */
+  readonly bar?: FqnOfTestTypeBar;
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'foo': obj.foo?.value,
+    'bar': obj.bar?.value,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+
+/**
+ * @schema FqnOfTestTypeFoo
+ */
+export class FqnOfTestTypeFoo {
+  public static fromBoolean(value: boolean): FqnOfTestTypeFoo {
+    return new FqnOfTestTypeFoo(value);
+  }
+  private constructor(public readonly value: boolean) {
+  }
+}
+
+/**
+ * @schema FqnOfTestTypeBar
+ */
+export class FqnOfTestTypeBar {
+  public static fromBoolean(value: boolean): FqnOfTestTypeBar {
+    return new FqnOfTestTypeBar(value);
+  }
+  private constructor(public readonly value: boolean) {
+  }
+}
+"
+`;
+
 exports[`unions constraints are ignored for objects 1`] = `
 "/**
  * @schema TestType

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -112,6 +112,17 @@ describe('unions', () => {
       },
     },
   });
+
+  which.usingTransforms('convertNullUnionsToOptional')('are tuples with a null type', {
+    properties: {
+      foo: {
+        anyOf: [{ type: 'null' }, { type: 'boolean' }],
+      },
+      bar: {
+        oneOf: [{ type: 'null' }, { type: 'boolean' }],
+      },
+    },
+  });
 });
 
 


### PR DESCRIPTION
Opt-in transformer. Enable with `{ convertNullUnionsToOptional: true }`

---

Given a union schema where one of them is null:

```js
{
  properties: {
    foo: {
      anyOf: [
        { type: 'null' },
        { type: 'boolean' }
      ],
    }
  }
}
```

This used to produce:

```ts
export interface TestType {
  readonly foo?: any;
}
```

Now produces a union type:

```ts
export interface TestType {
  readonly foo?: FqnOfTestTypeFoo;
}
export class FqnOfTestTypeFoo {
  public static fromBoolean(value: boolean): FqnOfTestTypeFoo {
    return new FqnOfTestTypeFoo(value);
  }
  private constructor(public readonly value: boolean) {
  }
}
```

And when combined with `hoistSingletonUnions: true`, it will produce:

```ts
export interface TestType {
  readonly foo?: boolean;
}
```

---

### Ask Yourself

- [x] Have you reviewed the [contribution guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md)?
- [x] Have you reviewed the [breaking changes guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md#breaking-changes)?
