### PR TITLE
fix: unions with multiple of the same type produce invalid typescript

### DIFF
--- a/src/transfomers/union-duplicates.ts
+++ b/src/transfomers/union-duplicates.ts
@@ -1,0 +1,64 @@
+import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName } from 'json-schema';
+
+/**
+ * Reduces multiple occurrences of the same type in oneOf/anyOf into a single type.
+ * For enums, combines all enum values into a single enum.
+ */
+export function reduceDuplicateTypesInUnion(def: JSONSchema4): JSONSchema4 {
+  // If there's no oneOf or anyOf, return as is
+  if (!def.oneOf && !def.anyOf) {
+    return def;
+  }
+
+  const union = def.oneOf || def.anyOf;
+  if (!Array.isArray(union)) {
+    return def;
+  }
+
+  // Group types by their type property
+  const typeGroups = new Map<JSONSchema4TypeName | JSONSchema4TypeName[], JSONSchema4[]>();
+  for (const item of union) {
+    const key = item.type || 'any';
+    if (!typeGroups.has(key)) {
+      typeGroups.set(key, []);
+    }
+    typeGroups.get(key)!.push(item);
+  }
+
+  // For each group, if there are multiple items:
+  // - For enums: combine all enum values
+  // - For other types: keep only one instance
+  const reducedUnion: JSONSchema4[] = [];
+  for (const [type, items] of typeGroups.entries()) {
+    if (items.length === 1) {
+      reducedUnion.push(items[0]);
+      continue;
+    }
+
+    // If these are enums, combine their values
+    if (items.every(item => Array.isArray(item.enum))) {
+      const combinedEnum = new Set<JSONSchema4Type>();
+      for (const item of items) {
+        for (const value of item.enum!) {
+          combinedEnum.add(value);
+        }
+      }
+      reducedUnion.push({
+        type,
+        enum: Array.from(combinedEnum),
+      });
+    } else {
+      // For non-enums, just keep the first one
+      reducedUnion.push(items[0]);
+    }
+  }
+
+  // Update the original definition
+  if (def.oneOf) {
+    def.oneOf = reducedUnion;
+  } else {
+    def.anyOf = reducedUnion;
+  }
+
+  return def;
+}

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -6,6 +6,7 @@ import { Code } from './code';
 import { ToJsonFunction } from './tojson';
 import { reduceNullUnion } from './transfomers/null-union';
 import { hoistSingletonUnion } from './transfomers/singleton-union';
+import { reduceDuplicateTypesInUnion } from './transfomers/union-duplicates';
 
 
 const PRIMITIVE_TYPES = ['string', 'number', 'integer', 'boolean'];
@@ -191,6 +192,7 @@ export class TypeGenerator {
   private transformTypes(def: JSONSchema4): JSONSchema4 {
     const transformers: Array<(def: JSONSchema4) => JSONSchema4> = [
       reduceNullUnion,
+      reduceDuplicateTypesInUnion,
 
       // needs to run towards the end to have the most effect
       hoistSingletonUnion,

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -1523,6 +1523,72 @@ export function toJson_TestTypeFaultDelayPercentage(obj: TestTypeFaultDelayPerce
 "
 `;
 
+exports[`unions have multiple enums 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#foo
+   */
+  readonly foo?: FqnOfTestTypeFoo;
+
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'foo': obj.foo,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+
+/**
+ * @schema FqnOfTestTypeFoo
+ */
+export enum FqnOfTestTypeFoo {
+  /** tab */
+  TAB = \\"tab\\",
+  /** space */
+  SPACE = \\"space\\",
+}
+"
+`;
+
+exports[`unions have multiple of the same type 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#foo
+   */
+  readonly foo?: boolean;
+
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'foo': obj.foo,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+"
+`;
+
 exports[`unions have only one type 1`] = `
 "/**
  * @schema fqn.of.TestType

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -87,6 +87,39 @@ describe('unions', () => {
       },
     },
   });
+
+  which('have multiple of the same type', {
+    properties: {
+      foo: {
+        oneOf: [
+          { type: 'boolean' },
+          { type: 'boolean' },
+        ],
+      },
+    },
+  });
+
+
+  which('have multiple enums', {
+    properties: {
+      foo: {
+        oneOf: [
+          {
+            type: 'string',
+            enum: [
+              'tab',
+            ],
+          },
+          {
+            type: 'string',
+            enum: [
+              'space',
+            ],
+          },
+        ],
+      },
+    },
+  });
 });
 
 


### PR DESCRIPTION
Previously a schema like this:

```
{
  properties: {
    foo: {
      oneOf: [
        {
          type: 'string',
          enum: [
            'tab',
          ],
        },
        {
          type: 'string',
          enum: [
            'space',
          ],
        },
      ],
    },
  },
}
```

was producing invalid typescript code:
```ts
export interface TestType {
  readonly foo?: FqnOfTestTypeFoo;
}
export class FqnOfTestTypeFoo {
  public static fromString(value: string): Foo {
    return new FqnOfTestTypeFoo(value);
  }
  public static fromString(value: string): Foo {
    return new FqnOfTestTypeFoo(value);
  }
  private constructor(public readonly value: string | string) {
  }
}
```

instead we now create valid code:


```ts
export interface TestType {
  readonly foo?: FqnOfTestTypeFoo;
}
export enum FqnOfTestTypeFoo {
  /** tab */
  TAB = "tab",
  /** space */
  SPACE = "space",
}
```

Adds a new transformer that:
- Combines multiple occurrences of the same type in oneOf/anyOf into a single type
- Merges enum values when multiple enum types of the same base type are present
- Fixes generated TypeScript interfaces by eliminating redundant union types

---

### Ask Yourself

- [x] Have you reviewed the [contribution guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md)?
- [x] Have you reviewed the [breaking changes guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md#breaking-changes)?
