### PR TITLE
fix: unions with multiple of the same type produce invalid typescript

### DIFF
--- a/src/transfomers/null-type-array.ts
+++ b/src/transfomers/null-type-array.ts
@@ -1,0 +1,44 @@
+import { JSONSchema4 } from 'json-schema';
+
+/**
+ * Many schemas define a type as an array of types to indicate union types.
+ * To avoid having the type generator be aware of that, we transform those types
+ * into their corresponding typescript definitions.
+ *
+ * --------------------------------------------------
+ *
+ * Strictly speaking, these definitions are meant to allow the literal 'null' value
+ * to be used in addition to the actual types. However, since union types are not supported
+ * in jsii, allowing this would mean falling back to 'any' and loosing all type safety for such
+ * properties. Transforming it into a single concrete optional type provides both type safety and
+ * the option to omit the property. What it doesn't allow is explicitly passing 'null', which might
+ * be desired in some cases. For now we prefer type safety over that.
+ *
+ * 1. ['null', '<type>'] -> optional '<type>'
+ * 2. ['null', '<type1>', '<type2>'] -> optional 'any'
+ *
+ * This is the normal jsii conversion, nothing much we can do here.
+ *
+ * 3. ['<type1>', '<type2>'] -> 'any'
+ */
+export function reduceNullTypeArray(def: JSONSchema4): JSONSchema4 {
+  if (!Array.isArray(def.type)) {
+    return def;
+  }
+
+  const nullType = def.type.some(t => t === 'null');
+  const nonNullTypes = new Set(def.type.filter(t => t !== 'null'));
+
+  if (nullType) {
+    def.required = false;
+  }
+
+  if (nonNullTypes.size === 0) {
+    def.type = 'null';
+  } else {
+    // if its a union of non null types we use 'any' to be jsii compliant
+    def.type = nonNullTypes.size > 1 ? 'any' : nonNullTypes.values().next().value;
+  }
+
+  return def;
+}

--- a/src/transfomers/union-duplicates.ts
+++ b/src/transfomers/union-duplicates.ts
@@ -1,0 +1,64 @@
+import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName } from 'json-schema';
+
+/**
+ * Reduces multiple occurrences of the same type in oneOf/anyOf into a single type.
+ * For enums, combines all enum values into a single enum.
+ */
+export function reduceDuplicateTypesInUnion(def: JSONSchema4): JSONSchema4 {
+  // If there's no oneOf or anyOf, return as is
+  if (!def.oneOf && !def.anyOf) {
+    return def;
+  }
+
+  const union = def.oneOf || def.anyOf;
+  if (!Array.isArray(union)) {
+    return def;
+  }
+
+  // Group types by their type property
+  const typeGroups = new Map<JSONSchema4TypeName | JSONSchema4TypeName[], JSONSchema4[]>();
+  for (const item of union) {
+    const key = item.type || 'any';
+    if (!typeGroups.has(key)) {
+      typeGroups.set(key, []);
+    }
+    typeGroups.get(key)!.push(item);
+  }
+
+  // For each group, if there are multiple items:
+  // - For enums: combine all enum values
+  // - For other types: keep only one instance
+  const reducedUnion: JSONSchema4[] = [];
+  for (const [type, items] of typeGroups.entries()) {
+    if (items.length === 1) {
+      reducedUnion.push(items[0]);
+      continue;
+    }
+
+    // If these are enums, combine their values
+    if (items.every(item => Array.isArray(item.enum))) {
+      const combinedEnum = new Set<JSONSchema4Type>();
+      for (const item of items) {
+        for (const value of item.enum!) {
+          combinedEnum.add(value);
+        }
+      }
+      reducedUnion.push({
+        type,
+        enum: Array.from(combinedEnum),
+      });
+    } else {
+      // For non-enums, just keep the first one
+      reducedUnion.push(items[0]);
+    }
+  }
+
+  // Update the original definition
+  if (def.oneOf) {
+    def.oneOf = reducedUnion;
+  } else {
+    def.anyOf = reducedUnion;
+  }
+
+  return def;
+}

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -4,6 +4,8 @@ import { snakeCase } from 'snake-case';
 import { NAMED_SYMBOLS } from './allowlist';
 import { Code } from './code';
 import { ToJsonFunction } from './tojson';
+import { reduceNullTypeArray } from './transfomers/null-type-array';
+import { reduceDuplicateTypesInUnion } from './transfomers/union-duplicates';
 
 
 const PRIMITIVE_TYPES = ['string', 'number', 'integer', 'boolean'];
@@ -186,45 +188,25 @@ export class TypeGenerator {
   }
 
   /**
-   * Many schemas define a type as an array of types to indicate union types.
-   * To avoid having the type generator be aware of that, we transform those types
-   * into their corresponding typescript definitions.
-   * --------------------------------------------------
+   * Many schemas define a type in ways that make sense for a schema,
+   * but cannot easily be represented in jsii.
+   * However often it is possible to transform these into a simplified version
+   * of the same type, that will have the same semantic meaning in jsii.
    *
-   * Strictly speaking, these definitions are meant to allow the liternal 'null' value
-   * to be used in addition to the actual types. However, since union types are not supported
-   * in jsii, allowing this would mean falling back to 'any' and loosing all type safety for such
-   * properties. Transforming it into a single concrete optional type provides both type safety and
-   * the option to omit the property. What it doesn't allow is explicitly passing 'null', which might
-   * be desired in some cases. For now we prefer type safety over that.
+   * To avoid having the type generator be aware of all these cases,
+   * we transform those types into their corresponding simplified definitions.
    *
-   * 1. ['null', '<type>'] -> optional '<type>'
-   * 2. ['null', '<type1>', '<type2>'] -> optional 'any'
-   *
-   * This is the normal jsii conversion, nothing much we can do here.
-   *
-   * 3. ['<type1>', '<type2>'] -> 'any'
+   * @param def - the schema to be transformed
    */
-  private maybeTransformTypeArray(def: JSONSchema4) {
+  private transformTypes(def: JSONSchema4): JSONSchema4 {
+    const transformers: Array<(def: JSONSchema4) => JSONSchema4> = [
+      reduceNullTypeArray,
+      reduceDuplicateTypesInUnion,
+    ];
 
-    if (!Array.isArray(def.type)) {
-      return;
-    }
-
-    const nullType = def.type.some(t => t === 'null');
-    const nonNullTypes = new Set(def.type.filter(t => t !== 'null'));
-
-    if (nullType) {
-      def.required = false;
-    }
-
-    if (nonNullTypes.size === 0) {
-      def.type = 'null';
-    } else {
-      // if its a union of non null types we use 'any' to be jsii compliant
-      def.type = nonNullTypes.size > 1 ? 'any' : nonNullTypes.values().next().value;
-    }
-
+    // const deepCopiedDef = JSON.parse(JSON.stringify(def));
+    const deepCopiedDef = def;
+    return transformers.reduce((input, transform) => transform(input), deepCopiedDef);
   }
 
   /**
@@ -246,7 +228,7 @@ export class TypeGenerator {
       }
     }
 
-    this.maybeTransformTypeArray(def);
+    def = this.transformTypes(def);
 
     if (def.enum && this.sanitizeEnums) {
       // santizie enums from liternal 'null' because they prevent emitting the enum

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -1353,7 +1353,6 @@ export interface TestType {
    * @schema fqn.of.TestType#bar
    */
   readonly bar?: boolean;
-
 }
 
 /**
@@ -1515,7 +1514,6 @@ export interface TestType {
    * @schema fqn.of.TestType#foo
    */
   readonly foo?: FqnOfTestTypeFoo;
-
 }
 
 /**
@@ -1554,7 +1552,6 @@ export interface TestType {
    * @schema fqn.of.TestType#foo
    */
   readonly foo?: FqnOfTestTypeFoo;
-
 }
 
 /**

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -1317,16 +1317,58 @@ export function toJson_TypeC(obj: TypeC | undefined): Record<string, any> | unde
 "
 `;
 
-exports[`type can be an array with null and a single non null type 1`] = `
+exports[`type arrays have a single type 1`] = `
 "/**
- * @schema Foo
+ * @schema fqn.of.TestType
  */
-export interface Foo {
+export interface TestType {
   /**
-   * @schema Foo#bar
+   * @schema fqn.of.TestType#bar
    */
   readonly bar?: boolean;
 }
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'bar': obj.bar,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+"
+`;
+
+exports[`type arrays have null and a single non null type 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#bar
+   */
+  readonly bar?: boolean;
+
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'bar': obj.bar,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
 "
 `;
 
@@ -1461,6 +1503,84 @@ export function toJson_TestTypeFaultDelayPercentage(obj: TestTypeFaultDelayPerce
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+"
+`;
+
+exports[`unions have multiple enums 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#foo
+   */
+  readonly foo?: FqnOfTestTypeFoo;
+
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'foo': obj.foo?.value,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+
+/**
+ * @schema FqnOfTestTypeFoo
+ */
+export class FqnOfTestTypeFoo {
+  public static fromString(value: string): FqnOfTestTypeFoo {
+    return new FqnOfTestTypeFoo(value);
+  }
+  private constructor(public readonly value: string) {
+  }
+}
+"
+`;
+
+exports[`unions have multiple of the same type 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#foo
+   */
+  readonly foo?: FqnOfTestTypeFoo;
+
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'foo': obj.foo?.value,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+
+/**
+ * @schema FqnOfTestTypeFoo
+ */
+export class FqnOfTestTypeFoo {
+  public static fromBoolean(value: boolean): FqnOfTestTypeFoo {
+    return new FqnOfTestTypeFoo(value);
+  }
+  private constructor(public readonly value: boolean) {
+  }
+}
 "
 `;
 

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -66,6 +66,38 @@ describe('unions', () => {
     },
   });
 
+  which('have multiple of the same type', {
+    properties: {
+      foo: {
+        oneOf: [
+          { type: 'boolean' },
+          { type: 'boolean' },
+        ],
+      },
+    },
+  });
+
+
+  which('have multiple enums', {
+    properties: {
+      foo: {
+        oneOf: [
+          {
+            type: 'string',
+            enum: [
+              'tab',
+            ],
+          },
+          {
+            type: 'string',
+            enum: [
+              'space',
+            ],
+          },
+        ],
+      },
+    },
+  });
 });
 
 
@@ -453,20 +485,18 @@ test('if "toJsonInternal" is enabled, toJson functions are marked as @internal',
   expect(await generate(gen)).toMatchSnapshot();
 });
 
-test('type can be an array with null and a single non null type', async () => {
-
-  const schema: JSONSchema4 = {
+describe('type arrays', () => {
+  which('have null and a single non null type', {
     properties: {
       bar: { type: ['null', 'boolean'] },
     },
-  };
-
-  const gen = TypeGenerator.forStruct('Foo', schema, {
-    toJson: false,
   });
 
-  expect(await generate(gen)).toMatchSnapshot();
-
+  which('have a single type', {
+    properties: {
+      bar: { type: ['boolean'] },
+    },
+  });
 });
 
 test('additionalProperties when type is defined as array', async () => {


### PR DESCRIPTION
Previously a schema like this:

```
{
  properties: {
    foo: {
      oneOf: [
        {
          type: 'string',
          enum: [
            'tab',
          ],
        },
        {
          type: 'string',
          enum: [
            'space',
          ],
        },
      ],
    },
  },
}
```

was producing invalid typescript code (note the doubling of `fromString`):
```ts
export interface TestType {
  readonly foo?: FqnOfTestTypeFoo;
}
export class FqnOfTestTypeFoo {
  public static fromString(value: string): Foo {
    return new FqnOfTestTypeFoo(value);
  }
  public static fromString(value: string): Foo {
    return new FqnOfTestTypeFoo(value);
  }
  private constructor(public readonly value: string | string) {
  }
}
```

instead we now create valid code:


```ts
export interface TestType {
  readonly foo?: FqnOfTestTypeFoo;
}
export enum FqnOfTestTypeFoo {
  /** tab */
  TAB = "tab",
  /** space */
  SPACE = "space",
}
```

---

Introduces the new concept of transformers. Transformers are either mandatory or opt-in (not yet available) conversions of JSONSchema definitions into a simplified, but semantically equivalent form. This reduces the need for the type generator to be aware of edge cases, but also gives the user more control over how to handle edge cases.

**Mandatory transformers** are such ones necessary to generate valid code. An example is available in this PR: A union schema with multiple of the same type produces invalid code, thus reducing the union to elements of unique types is a mandatory transform.

**Opt-in transformers** are such ones that improve the generated code, but are either not backwards compatible or carry the risk of it. For example a union schema with a single element could be "hoisted" up to the top level to avoid the union all together. This produces cleaner code. However the schema author might have use a union to convey their intention of adding further elements into the union in future, which would than cause a breaking change in the generated code.

---

### Ask Yourself

- [x] Have you reviewed the [contribution guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md)?
- [x] Have you reviewed the [breaking changes guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md#breaking-changes)?
