### PR TITLE
fix: remove extra newline at end of structs

### DIFF
--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -464,8 +464,12 @@ export class TypeGenerator {
       this.emitDescription(code, structFqn, structDef.description);
       code.openBlock(`export interface ${typeName}`);
 
-      for (const [propName, propSpec] of Object.entries(structDef.properties || {})) {
+      const props = Object.entries(structDef.properties || {});
+      for (const [idx, [propName, propSpec]] of props.entries()) {
         this.emitProperty(code, propName, propSpec, structFqn, structDef, toJson);
+        if (idx < props.length - 1) {
+          code.line();
+        }
       }
 
       code.closeBlock();
@@ -510,7 +514,6 @@ export class TypeGenerator {
     const optional = required ? '' : '?';
 
     code.line(`readonly ${name}${optional}: ${propertyType.type};`);
-    code.line();
 
     toJson.addField(originalName, name, propertyType.toJson);
     this.emittedProperties.add(propertyFqn);

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -90,7 +90,6 @@ export interface MyStruct {
    * @schema MyStruct#VPCConfiguration
    */
   readonly vpcConfiguration?: MyStructVpcConfiguration;
-
 }
 
 /**
@@ -137,7 +136,6 @@ export interface MyStructVpcConfiguration {
    * @schema MyStructVpcConfiguration#SubnetIds
    */
   readonly subnetIds?: string[];
-
 }
 
 /**
@@ -248,7 +246,6 @@ export interface MyStruct {
    * @schema MyStruct#Modified
    */
   readonly modified?: Date;
-
 }
 
 /**
@@ -301,7 +298,6 @@ export interface Creator {
    * @schema Creator#Email
    */
   readonly email?: string;
-
 }
 
 /**
@@ -337,7 +333,6 @@ export interface Query {
    * @schema Query#Denominator
    */
   readonly denominator?: string;
-
 }
 
 /**
@@ -393,7 +388,6 @@ export interface Threshold {
    * @schema Threshold#WarningDisplay
    */
   readonly warningDisplay?: string;
-
 }
 
 /**
@@ -558,7 +552,6 @@ export interface MyStruct {
    * @schema MyStruct#Tags
    */
   readonly tags?: MyStructTags[];
-
 }
 
 /**
@@ -604,7 +597,6 @@ export interface MyStructKubernetesNetworkConfig {
    * @schema MyStructKubernetesNetworkConfig#ServiceIpv4Cidr
    */
   readonly serviceIpv4Cidr?: string;
-
 }
 
 /**
@@ -661,7 +653,6 @@ export interface MyStructResourcesVpcConfig {
    * @schema MyStructResourcesVpcConfig#PublicAccessCidrs
    */
   readonly publicAccessCidrs?: string[];
-
 }
 
 /**
@@ -699,7 +690,6 @@ export interface EncryptionConfigEntry {
    * @schema EncryptionConfigEntry#Provider
    */
   readonly provider?: Provider;
-
 }
 
 /**
@@ -730,7 +720,6 @@ export interface MyStructKubernetesApiAccess {
    * @schema MyStructKubernetesApiAccess#Users
    */
   readonly users?: KubernetesApiAccessEntry[];
-
 }
 
 /**
@@ -761,7 +750,6 @@ export interface MyStructTags {
    * @schema MyStructTags#Key
    */
   readonly key: string;
-
 }
 
 /**
@@ -791,7 +779,6 @@ export interface Provider {
    * @schema Provider#KeyArn
    */
   readonly keyArn?: string;
-
 }
 
 /**
@@ -826,7 +813,6 @@ export interface KubernetesApiAccessEntry {
    * @schema KubernetesApiAccessEntry#Groups
    */
   readonly groups?: string[];
-
 }
 
 /**

--- a/test/__snapshots__/tojson.test.ts.snap
+++ b/test/__snapshots__/tojson.test.ts.snap
@@ -9,7 +9,6 @@ export interface MyStruct {
    * @schema MyStruct#MyAny
    */
   readonly myAny?: any;
-
 }
 
 /**
@@ -37,7 +36,6 @@ export interface MyStruct {
    * @schema MyStruct#Array_Of_complex
    */
   readonly arrayOfComplex?: MyType[];
-
 }
 
 /**
@@ -67,7 +65,6 @@ export interface MyType {
    * @schema MyType#Bar
    */
   readonly bar?: string;
-
 }
 
 /**
@@ -96,7 +93,6 @@ export interface MyStruct {
    * @schema MyStruct#ArrayProp
    */
   readonly arrayProp?: string[];
-
 }
 
 /**
@@ -124,7 +120,6 @@ export interface MyStruct {
    * @schema MyStruct#ArrayProp
    */
   readonly arrayProp?: string[];
-
 }
 
 /**
@@ -152,7 +147,6 @@ export interface MyStruct {
    * @schema MyStruct#ArrayProp
    */
   readonly arrayProp?: any[];
-
 }
 
 /**
@@ -180,7 +174,6 @@ export interface MyStruct {
    * @schema MyStruct#ComplexType
    */
   readonly complexType?: MyType;
-
 }
 
 /**
@@ -215,7 +208,6 @@ export interface MyType {
    * @schema MyType#Nested
    */
   readonly nested: YourType;
-
 }
 
 /**
@@ -242,7 +234,6 @@ export interface YourType {
    * @schema YourType#John
    */
   readonly john?: string[];
-
 }
 
 /**
@@ -270,7 +261,6 @@ export interface MyStruct {
    * @schema MyStruct#DateTime
    */
   readonly dateTime?: Date;
-
 }
 
 /**
@@ -303,7 +293,6 @@ export interface MyStruct {
    * @schema MyStruct#YourEnum
    */
   readonly yourEnum?: MyStructYourEnum;
-
 }
 
 /**
@@ -354,7 +343,6 @@ export interface MyStruct {
    * @schema MyStruct#ComplexMap
    */
   readonly complexMap?: { [key: string]: MyType };
-
 }
 
 /**
@@ -384,7 +372,6 @@ export interface MyType {
    * @schema MyType#Bar
    */
   readonly bar?: string;
-
 }
 
 /**
@@ -418,7 +405,6 @@ export interface MyStruct {
    * @schema MyStruct#NumberMap
    */
   readonly numberMap?: { [key: string]: number };
-
 }
 
 /**
@@ -462,7 +448,6 @@ export interface MyStruct {
    * @schema MyStruct#x-extension
    */
   readonly xExtension?: string;
-
 }
 
 /**
@@ -508,7 +493,6 @@ export interface MyStruct {
    * @schema MyStruct#With_UnderScore
    */
   readonly withUnderScore?: number;
-
 }
 
 /**
@@ -549,7 +533,6 @@ export interface MyStruct {
    * @schema MyStruct#Haver
    */
   readonly haver?: MyStructHaver;
-
 }
 
 /**
@@ -576,7 +559,6 @@ export interface ComplexType {
    * @schema ComplexType#Ref_to_union
    */
   readonly refToUnion?: IntOrString;
-
 }
 
 /**

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -655,7 +655,6 @@ export interface Foo {
    * @schema Foo#nested
    */
   readonly nested?: FooNested;
-
 }
 
 /**
@@ -682,7 +681,6 @@ export interface FooNested {
    * @schema FooNested#value
    */
   readonly value?: number;
-
 }
 
 /**

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -9,7 +9,6 @@ export interface Foo {
    * @schema Foo#foo
    */
   readonly foo?: { [key: string]: string };
-
 }
 "
 `;
@@ -43,7 +42,6 @@ export interface TestType {
    * @schema fqn.of.TestType#camel-case-5
    */
   readonly camelCase5?: string;
-
 }
 
 /**
@@ -75,7 +73,6 @@ export interface Bar {
    * @schema Bar#prop
    */
   readonly prop?: V1beta1Foo;
-
 }
 
 /**
@@ -100,7 +97,6 @@ export interface V1beta1Foo {
    * @schema io.k8s.v1beta1.Foo#props
    */
   readonly props?: number;
-
 }
 
 /**
@@ -158,7 +154,6 @@ export interface TestType {
    * @schema fqn.of.TestType#field
    */
   readonly field?: string;
-
 }
 
 /**
@@ -186,7 +181,6 @@ export interface TestType {
    * @schema fqn.of.TestType#field
    */
   readonly field?: boolean;
-
 }
 
 /**
@@ -216,7 +210,6 @@ export interface TestType {
    * @schema fqn.of.TestType#field
    */
   readonly field?: string;
-
 }
 
 /**
@@ -244,7 +237,6 @@ export interface Foo {
    * @schema Foo#foo
    */
   readonly foo?: FooFoo;
-
 }
 
 /**
@@ -268,7 +260,6 @@ export interface TestType {
    * @schema fqn.of.TestType#Chars
    */
   readonly chars?: FqnOfTestTypeChars;
-
 }
 
 /**
@@ -350,7 +341,6 @@ export interface TestType {
    * @schema fqn.of.TestType#Days
    */
   readonly days?: FqnOfTestTypeDays;
-
 }
 
 /**
@@ -390,7 +380,6 @@ export interface TestType {
    * @schema fqn.of.TestType#Percentiles
    */
   readonly percentiles?: FqnOfTestTypePercentiles;
-
 }
 
 /**
@@ -430,7 +419,6 @@ export interface TestType {
    * @schema fqn.of.TestType#Same
    */
   readonly same?: FqnOfTestTypeSame;
-
 }
 
 /**
@@ -483,7 +471,6 @@ export interface TestType {
    * @schema fqn.of.TestType#child
    */
   readonly child?: FqnOfTestTypeChild;
-
 }
 
 /**
@@ -527,7 +514,6 @@ export interface FqnOfTestTypeChild {
    * @schema FqnOfTestTypeChild#secondEnum
    */
   readonly secondEnum?: FqnOfTestTypeChildSecondEnum;
-
 }
 
 /**
@@ -571,7 +557,6 @@ export interface TestType {
    * @schema fqn.of.TestType#Timeframe
    */
   readonly timeframe?: FqnOfTestTypeTimeframe;
-
 }
 
 /**
@@ -613,7 +598,6 @@ export interface TestType {
    * @schema fqn.of.TestType#Color
    */
   readonly color?: FqnOfTestTypeColor;
-
 }
 
 /**
@@ -653,7 +637,6 @@ export interface Foo {
    * @schema Foo#bar
    */
   readonly bar?: string;
-
 }
 "
 `;
@@ -702,7 +685,6 @@ export interface TestType {
    * @schema fqn.of.TestType#integerValue
    */
   readonly integerValue?: number;
-
 }
 
 /**
@@ -737,7 +719,6 @@ export interface Foo {
    * @schema Foo#bar
    */
   readonly bar?: string;
-
 }
 "
 `;
@@ -751,7 +732,6 @@ export interface Foo {
    * @schema Foo#foo
    */
   readonly foo?: FooFoo;
-
 }
 
 /**
@@ -773,7 +753,6 @@ export interface Foo {
    * @schema Foo#foo
    */
   readonly foo?: FooFoo;
-
 }
 
 /**
@@ -795,7 +774,6 @@ export interface Bar1 {
    * @schema Bar1#prop
    */
   readonly prop?: IoK8Sv1Beta1Foo;
-
 }
 
 /**
@@ -820,7 +798,6 @@ export interface Bar2 {
    * @schema Bar2#prop
    */
   readonly prop?: IoK8Sv1Foo;
-
 }
 
 /**
@@ -845,7 +822,6 @@ export interface IoK8Sv1Beta1Foo {
    * @schema io.k8s.v1beta1.Foo#props
    */
   readonly props?: number;
-
 }
 
 /**
@@ -870,7 +846,6 @@ export interface IoK8Sv1Foo {
    * @schema io.k8s.v1.Foo#props
    */
   readonly props?: string;
-
 }
 
 /**
@@ -908,7 +883,6 @@ export interface TestType {
    * @schema fqn.of.TestType#arrayShouldBeOptional
    */
   readonly arrayShouldBeOptional?: ItemType[];
-
 }
 
 /**
@@ -935,7 +909,6 @@ export interface ItemType {
    * @schema ItemType#requiredField
    */
   readonly requiredField: string;
-
 }
 
 /**
@@ -963,7 +936,6 @@ export interface TestType {
    * @schema fqn.of.TestType#other
    */
   readonly other?: Other;
-
 }
 
 /**
@@ -988,7 +960,6 @@ export interface Other {
    * @schema Other#stringValue
    */
   readonly stringValue: string;
-
 }
 
 /**
@@ -1036,7 +1007,6 @@ export interface TestType {
    * @schema fqn.of.TestType#arrayOfString
    */
   readonly arrayOfString?: string[];
-
 }
 
 /**
@@ -1068,7 +1038,6 @@ export interface TestType {
    * @schema fqn.of.TestType#foo
    */
   readonly foo?: string;
-
 }
 
 /**
@@ -1135,7 +1104,6 @@ export interface TestType {
    * @schema fqn.of.TestType#NonCamelCaseRequired
    */
   readonly nonCamelCaseRequired: string;
-
 }
 
 /**
@@ -1168,7 +1136,6 @@ export interface TestType {
    * @schema fqn.of.TestType#entrypoint
    */
   readonly entrypoint?: MyType;
-
 }
 
 /**
@@ -1193,7 +1160,6 @@ export interface MyType {
    * @schema MyType#self
    */
   readonly self?: MyType;
-
 }
 
 /**
@@ -1223,7 +1189,6 @@ export interface TypeB {
    * @schema TypeB#refToTypeA
    */
   readonly refToTypeA?: NewType;
-
 }
 
 /**
@@ -1251,7 +1216,6 @@ export interface TypeA {
    * @schema TypeA#ref
    */
   readonly ref?: TypeC;
-
 }
 
 /**
@@ -1276,7 +1240,6 @@ export interface TypeC {
    * @schema TypeC#field
    */
   readonly field?: string;
-
 }
 
 /**
@@ -1304,7 +1267,6 @@ export interface Foo {
    * @schema Foo#bar
    */
   readonly bar?: boolean;
-
 }
 "
 `;
@@ -1321,7 +1283,6 @@ export interface TestType {
    * @schema TestType#fault
    */
   readonly fault?: TestTypeFault;
-
 }
 
 /**
@@ -1349,7 +1310,6 @@ export interface TestTypeFault {
    * @schema TestTypeFault#delay
    */
   readonly delay?: TestTypeFaultDelay;
-
 }
 
 /**
@@ -1397,7 +1357,6 @@ export interface TestTypeFaultDelay {
    * @schema TestTypeFaultDelay#percentage
    */
   readonly percentage?: TestTypeFaultDelayPercentage;
-
 }
 
 /**
@@ -1428,7 +1387,6 @@ export interface TestTypeFaultDelayPercentage {
    * @schema TestTypeFaultDelayPercentage#value
    */
   readonly value?: number;
-
 }
 
 /**

--- a/test/__snapshots__/usage.test.ts.snap
+++ b/test/__snapshots__/usage.test.ts.snap
@@ -19,7 +19,6 @@ export interface Person {
    * @schema Person#favorite_color
    */
   readonly favoriteColor?: PersonFavoriteColor;
-
 }
 
 /**
@@ -56,7 +55,6 @@ export interface Name {
    * @schema Name#last_name
    */
   readonly lastName: string;
-
 }
 
 /**


### PR DESCRIPTION
Instead of
```ts
interface Foo {
  readonly bar?: string;

}
```

we emit now

```ts
interface Foo {
  readonly bar?: string;
}
```

---

### Ask Yourself

- [x] Have you reviewed the [contribution guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md)?
- [x] Have you reviewed the [breaking changes guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md#breaking-changes)?