### PR TITLE
feat(json2jsii): add option to mark toJson functions as internal

### DIFF
--- a/src/tojson.ts
+++ b/src/tojson.ts
@@ -8,7 +8,7 @@ export class ToJsonFunction {
 
   private readonly fields: Record<string, string> = {};
 
-  constructor(private readonly baseType: string) {
+  constructor(private readonly baseType: string, private readonly internal: boolean = false) {
     this.functionName = `toJson_${baseType}`;
   }
 
@@ -35,6 +35,9 @@ export class ToJsonFunction {
     code.line();
     code.line('/**');
     code.line(` * Converts an object of type '${this.baseType}' to JSON representation.`);
+    if (this.internal) {
+      code.line(' * @internal');
+    }
     code.line(' */');
     code.line(`/* eslint-disable ${disabledEslintRules.join(', ')} */`);
     code.openBlock(`export function ${this.functionName}(obj: ${this.baseType} | undefined): Record<string, any> | undefined`);

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -37,6 +37,14 @@ export interface TypeGeneratorOptions {
   readonly toJson?: boolean;
 
   /**
+   * When true, generated `toJson_Xyz` functions will be marked with `@internal` tag.
+   * This is useful when you want to hide these functions from public API documentation.
+   *
+   * @default false
+   */
+  readonly toJsonInternal?: boolean;
+
+  /**
    * When set to true, enums are sanitized from the 'null' literal value,
    * allowing typing the property as an enum, instead of the underlying type.
    *
@@ -119,6 +127,7 @@ export class TypeGenerator {
   private readonly exclude: string[];
   private readonly definitions: { [def: string]: JSONSchema4 };
   private readonly toJson: boolean;
+  private readonly toJsonInternal: boolean;
   private readonly sanitizeEnums: boolean;
   private readonly renderTypeName: (def: string) => string;
 
@@ -131,6 +140,7 @@ export class TypeGenerator {
     this.exclude = options.exclude ?? [];
     this.definitions = {};
     this.toJson = options.toJson ?? true;
+    this.toJsonInternal = options.toJsonInternal ?? false;
     this.sanitizeEnums = options.sanitizeEnums ?? false;
     this.renderTypeName = options.renderTypeName ?? DEFAULT_RENDER_TYPE_NAME;
 
@@ -453,7 +463,7 @@ export class TypeGenerator {
   }
 
   private emitStruct(typeName: string, structDef: JSONSchema4, structFqn: string): EmittedType {
-    const toJson = new ToJsonFunction(typeName);
+    const toJson = new ToJsonFunction(typeName, this.toJsonInternal);
     const emitted: EmittedType = {
       type: typeName,
       toJson: x => `${toJson.functionName}(${x})`,

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -658,6 +658,67 @@ export interface Foo {
 "
 `;
 
+exports[`if "toJsonInternal" is enabled, toJson functions are marked as @internal 1`] = `
+"/**
+ * @schema Foo
+ */
+export interface Foo {
+  /**
+   * @schema Foo#bar
+   */
+  readonly bar?: string;
+
+  /**
+   * @schema Foo#nested
+   */
+  readonly nested?: FooNested;
+
+}
+
+/**
+ * Converts an object of type 'Foo' to JSON representation.
+ * @internal
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_Foo(obj: Foo | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'bar': obj.bar,
+    'nested': toJson_FooNested(obj.nested),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+
+/**
+ * @schema FooNested
+ */
+export interface FooNested {
+  /**
+   * @schema FooNested#value
+   */
+  readonly value?: number;
+
+}
+
+/**
+ * Converts an object of type 'FooNested' to JSON representation.
+ * @internal
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_FooNested(obj: FooNested | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'value': obj.value,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+"
+`;
+
 exports[`primitives 1`] = `
 "/**
  * @schema fqn.of.TestType

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -432,6 +432,27 @@ test('if "toJson" is disabled, toJson functions are not generated', async () => 
   expect(await generate(gen)).toMatchSnapshot();
 });
 
+test('if "toJsonInternal" is enabled, toJson functions are marked as @internal', async () => {
+  const schema: JSONSchema4 = {
+    properties: {
+      bar: { type: 'string' },
+      nested: {
+        type: 'object',
+        properties: {
+          value: { type: 'number' },
+        },
+      },
+    },
+  };
+
+  const gen = TypeGenerator.forStruct('Foo', schema, {
+    toJson: true,
+    toJsonInternal: true,
+  });
+
+  expect(await generate(gen)).toMatchSnapshot();
+});
+
 test('type can be an array with null and a single non null type', async () => {
 
   const schema: JSONSchema4 = {


### PR DESCRIPTION
Adds a new option 'toJsonInternal' that allows marking toJson functions with @internal JSDoc tag.

This is useful when you want to hide these functions from public API documentation.

- [x] Have you reviewed the [contribution guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md)?
- [x] Have you reviewed the [breaking changes guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md#breaking-changes)?