### PR TITLE
feat: (opt-in) unions of a type and an array of that same type can be the array type

### DIFF
--- a/src/transformers/array-union-reducer.ts
+++ b/src/transformers/array-union-reducer.ts
@@ -1,0 +1,34 @@
+import { JSONSchema4 } from 'json-schema';
+import { removeUnions, safeSelectUnion } from './util';
+
+/**
+ * When a schema defines a union between an array type and its element type,
+ * we can simplify it to just the array type since in jsii this would be 'any' anyway.
+ * For example: string | string[] becomes just string[]
+ */
+export function reduceArrayUnions(def: JSONSchema4): JSONSchema4 {
+  // bail if we cannot safely select a union or the union is not a tuple
+  const union = safeSelectUnion(def);
+  if (!union || union.length !== 2) {
+    return def;
+  }
+
+  // Look for a pattern where one type is an array and the other is its element type
+  const arrayType = union.find(t => t.type === 'array');
+  const elementType = union.find(t => t !== arrayType);
+
+  // bail, if we don't match the required pattern
+  if (!arrayType || !elementType || !arrayType.items) {
+    return def;
+  }
+
+  // Check if the element type matches the array items type
+  if (JSON.stringify(arrayType.items) === JSON.stringify(elementType)) {
+    // Replace the union with just the array type
+    removeUnions(def);
+    delete def.type;
+    Object.assign(def, arrayType);
+  }
+
+  return def;
+}

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -2,3 +2,4 @@ export * from './null-in-type-array';
 export * from './null-in-union';
 export * from './union-duplicates';
 export * from './singleton-unions';
+export * from './array-union-reducer';

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -1593,6 +1593,84 @@ export function toJson_TestTypeFaultDelayPercentage(obj: TestTypeFaultDelayPerce
 "
 `;
 
+exports[`unions have an array of a type and the same type simplifyElementArrayUnions disabled 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#foo
+   */
+  readonly foo?: any;
+
+  /**
+   * @schema fqn.of.TestType#bar
+   */
+  readonly bar?: any;
+
+  /**
+   * @schema fqn.of.TestType#baz
+   */
+  readonly baz?: any;
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'foo': obj.foo,
+    'bar': obj.bar,
+    'baz': obj.baz,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+"
+`;
+
+exports[`unions have an array of a type and the same type simplifyElementArrayUnions enabled 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#foo
+   */
+  readonly foo?: string[];
+
+  /**
+   * @schema fqn.of.TestType#bar
+   */
+  readonly bar?: boolean[];
+
+  /**
+   * @schema fqn.of.TestType#baz
+   */
+  readonly baz?: number[];
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'foo': obj.foo?.map(y => y),
+    'bar': obj.bar?.map(y => y),
+    'baz': obj.baz?.map(y => y),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+"
+`;
+
 exports[`unions have enums in unions 1`] = `
 "/**
  * @schema fqn.of.TestType

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -169,6 +169,30 @@ describe('unions', () => {
       },
     },
   });
+
+  which.usingTransforms('simplifyElementArrayUnions')('have an array of a type and the same type', {
+    properties: {
+      foo: {
+        anyOf: [
+          { type: 'array', items: { type: 'string' } },
+          { type: 'string' },
+        ],
+      },
+      bar: {
+        anyOf: [
+          { type: 'array', items: { type: 'boolean' } },
+          { type: 'boolean' },
+        ],
+      },
+      baz: {
+        allOf: [
+          { type: 'array', items: { type: 'number' } },
+          { type: 'number' },
+        ],
+      },
+    },
+  });
+
 });
 
 


### PR DESCRIPTION
Opt-in transformer. Enable with `{ simplifyElementArrayUnions: true }`.

When true, unions that contain an array type and its element type are simplified to just the array type. This is useful for jsii compatibility where such unions would be typed as 'any', but using just the array type provides better type safety while maintaining the same functionality since a single value can be wrapped in an array.

**Considerations**: This changes the schema's type structure but maintains semantic equivalence since single values can be wrapped in arrays. The transformation assumes that treating a single value as a single-element array is acceptable for the use case.

## Given

Given a union schema with a type and an array of that same type:

```js
{
  properties: {
    foo: {
      anyOf: [
        { type: 'array', items: { type: 'string' } },
        { type: 'string' },
      ]
    }
  }
}
```

## Before:

```
export interface TestType {
  readonly foo?: any;
}
```

## After:

```
export interface TestType {
  readonly foo?: string[];
}
```

---

### Ask Yourself

- [x] Have you reviewed the [contribution guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md)?
- [x] Have you reviewed the [breaking changes guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md#breaking-changes)?