### PR TITLE
fix(type-generator): references to primitive types are not resolved in unions

### DIFF
--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -1593,6 +1593,47 @@ export function toJson_TestTypeFaultDelayPercentage(obj: TestTypeFaultDelayPerce
 "
 `;
 
+exports[`unions have enums in unions 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#foo
+   */
+  readonly foo?: FqnOfTestTypeFoo;
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'foo': obj.foo?.value,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+
+/**
+ * @schema FqnOfTestTypeFoo
+ */
+export class FqnOfTestTypeFoo {
+  public static fromString(value: string): FqnOfTestTypeFoo {
+    return new FqnOfTestTypeFoo(value);
+  }
+  public static fromNumber(value: number): FqnOfTestTypeFoo {
+    return new FqnOfTestTypeFoo(value);
+  }
+  private constructor(public readonly value: string | number) {
+  }
+}
+"
+`;
+
 exports[`unions have multiple enums 1`] = `
 "/**
  * @schema fqn.of.TestType
@@ -1769,6 +1810,23 @@ export function toJson_TestType(obj: TestType | undefined): Record<string, any> 
 "
 `;
 
+exports[`unions include primitive types through references 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export class TestType {
+  public static fromString(value: string): TestType {
+    return new TestType(value);
+  }
+  public static fromNumber(value: number): TestType {
+    return new TestType(value);
+  }
+  private constructor(public readonly value: string | number) {
+  }
+}
+"
+`;
+
 exports[`unions include primitives 1`] = `
 "/**
  * @schema fqn.of.TestType
@@ -1785,3 +1843,5 @@ export class TestType {
 }
 "
 `;
+
+exports[`unions reject non-primitive types through references 1`] = `""`;

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -14,6 +14,35 @@ describe('unions', () => {
     ],
   });
 
+  which('include primitive types through references', {
+    oneOf: [
+      { type: 'string' },
+      { $ref: '#/definitions/NumberType' },
+    ],
+  }, {
+    definitions: {
+      NumberType: {
+        type: 'number',
+      },
+    },
+  });
+
+  which('reject non-primitive types through references', {
+    oneOf: [
+      { type: 'string' },
+      { $ref: '#/definitions/ObjectType' },
+    ],
+  }, {
+    definitions: {
+      ObjectType: {
+        type: 'object',
+        properties: {
+          foo: { type: 'string' },
+        },
+      },
+    },
+  });
+
   which('constraints are ignored for objects', {
     description: 'An ordered list of route rules for HTTP traffic.',
     type: 'array',
@@ -73,6 +102,23 @@ describe('unions', () => {
         oneOf: [
           { type: 'boolean' },
           { type: 'boolean' },
+        ],
+      },
+    },
+  });
+
+  which('have enums in unions', {
+    properties: {
+      foo: {
+        oneOf: [
+          {
+            type: 'string',
+            enum: ['A', 'B', 'C'],
+          },
+          {
+            type: 'number',
+            enum: [1, 2, 3],
+          },
         ],
       },
     },


### PR DESCRIPTION
Fixes an issue where references in union types were not being properly resolved.

## Given

```js
{
  definitions: {
    NumberType: {
      type: 'number',
    },
  },
  properties: {
    foo: {
      oneOf: [
        { type: 'string' },
        { $ref: '#/definitions/NumberType' },
      ]
    }
  }
}
```


## Before:

Would result in the union being dropped in favor of `any`:

```js
export interface TestType {
  readonly foo?: any;
}
```

## After:

The reference is resolved to the primitive type:

```js
export interface TestType {
  readonly foo?: FqnOfTestTypeFoo;
}

export class FqnOfTestTypeFoo {
  public static fromString(value: string): TestType {
    return new TestType(value);
  }
  public static fromNumber(value: number): TestType {
    return new TestType(value);
  }
  private constructor(public readonly value: string | number) {
  }
}
```


---

### Ask Yourself

- [x] Have you reviewed the [contribution guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md)?
- [x] Have you reviewed the [breaking changes guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md#breaking-changes)?