### PR TITLE
feat: support `$defs` under `$ref`

### DIFF
--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -1237,6 +1237,57 @@ export function toJson_MyType(obj: MyType | undefined): Record<string, any> | un
 "
 `;
 
+exports[`structs supports $defs references 1`] = `
+"/**
+ * @schema fqn.of.TestType
+ */
+export interface TestType {
+  /**
+   * @schema fqn.of.TestType#other
+   */
+  readonly other?: Other;
+}
+
+/**
+ * Converts an object of type 'TestType' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_TestType(obj: TestType | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'other': toJson_Other(obj.other),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+
+/**
+ * @schema Other
+ */
+export interface Other {
+  /**
+   * @schema Other#stringValue
+   */
+  readonly stringValue: string;
+}
+
+/**
+ * Converts an object of type 'Other' to JSON representation.
+ */
+/* eslint-disable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+export function toJson_Other(obj: Other | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'stringValue': obj.stringValue,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, @stylistic/max-len, quote-props, @stylistic/quote-props */
+"
+`;
+
 exports[`type aliases alias to a custom type 1`] = `
 "// this is NewType
 

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -231,6 +231,25 @@ describe('structs', () => {
     },
   });
 
+  which('supports $defs references', {
+    type: 'object',
+    properties: {
+      other: {
+        $ref: '#/$defs/Other',
+      },
+    },
+  }, {
+    definitions: {
+      Other: {
+        type: 'object',
+        properties: {
+          stringValue: { type: 'string' },
+        },
+        required: ['stringValue'],
+      },
+    },
+  });
+
   which('references itself', {
     type: 'object',
     properties: {


### PR DESCRIPTION
According to https://json-schema.org/draft/2019-09/release-notes#semi-incompatible-changes, the keyword "definitions" is deprecated and "$defs" is preferred.

Add support to the `$defs` keyword under `$ref`. The legacy `definitions` keyword is still supported, no breaking change.

Related to https://github.com/cdk8s-team/cdk8s/issues/2646

---

### Ask Yourself

- [x] Have you reviewed the [contribution guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md)?
- [x] Have you reviewed the [breaking changes guide](https://github.com/cdklabs/json2jsii/blob/main/CONTRIBUTING.md#breaking-changes)?
